### PR TITLE
Add ESLint Prettier plugin

### DIFF
--- a/discord-bot/.eslintrc.json
+++ b/discord-bot/.eslintrc.json
@@ -19,7 +19,8 @@
   },
   "plugins": [
     "@typescript-eslint",
-    "eslint-plugin-import"
+    "eslint-plugin-import",
+    "prettier"
   ],
   "settings": {
     "import/resolver": {
@@ -29,6 +30,7 @@
     }
   },
   "rules": {
+    "prettier/prettier": "error",
     "import/extensions": ["error", "never"],
     "no-console": "off",
     "@typescript-eslint/no-unused-vars": ["error"],

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@discordjs/opus": "^0.5.0",
     "@prisma/client": "^2.21.2",
-    "discord.js": "^12.5.3"
+    "discord.js": "^12.5.3",
+    "eslint-plugin-prettier": "^3.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/discord-bot/yarn.lock
+++ b/discord-bot/yarn.lock
@@ -2426,6 +2426,13 @@ eslint-plugin-import@^2.18.2:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-prettier@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
+  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2658,6 +2665,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.5"
@@ -4634,6 +4646,13 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@^2.1.2:
   version "2.2.1"


### PR DESCRIPTION
## What this is for

This will do 2 things:

- ESLint Prettier Config is just a config by prettier that turns off a lot of the rules that conflicts with prettier, which is IMO a terrible choice of a config name.
- Having Prettier as an ESLint config will ensure that there will be no conflict changes between before and after running the `yarn format` command, especially when it actually changes a folder that the developer is not working on.
e.g. if i'm just changing something in src/danhSomeone, I don't want `yarn format` to affect src/somethingElse.


## How it affects the code behaviour

We used to have this in `src/thanks/thankuser.ts`:

```ts
  const hasKeyword = thankKeywords.some((keyword) => msg.content.toLowerCase().includes(keyword));
```

When run through eslint check, it shows no error. But if we run `yarn format` with prettier, it will change the code into this:

```ts
  const hasKeyword = thankKeywords.some((keyword) =>
    msg.content.toLowerCase().includes(keyword)
  );
```

Which meant there was an error for prettier to fix.

## Expected behavior:

If we have prettier in the eslint config, and it's configured correctly in the first place (indicated by the config name), this shouldn't happen.

It should flag this as an error when put through eslint.

```ts
  const hasKeyword = thankKeywords.some((keyword) => msg.content.toLowerCase().includes(keyword));
```