### PR TITLE
Refactor tests, type coercion and finish coverage for remaining test cases

### DIFF
--- a/discord-bot/src/commands/8ball/index.test.ts
+++ b/discord-bot/src/commands/8ball/index.test.ts
@@ -12,7 +12,7 @@ describe('ask 8Ball test', () => {
     };
 
     await ask8Ball(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(1);
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 
   it('Should return if no question asked', async () => {
@@ -23,7 +23,7 @@ describe('ask 8Ball test', () => {
     };
 
     await ask8Ball(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('Should return if author is a bot', async () => {
@@ -34,6 +34,6 @@ describe('ask 8Ball test', () => {
     };
 
     await ask8Ball(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 });

--- a/discord-bot/src/commands/danhSomeone/index.test.ts
+++ b/discord-bot/src/commands/danhSomeone/index.test.ts
@@ -13,12 +13,8 @@ describe('danhSomeone', () => {
       content: '-hit',
       reply: replyMock,
       channel: { send: replyMock },
-      mentions: {
-        users: mockUsers,
-      },
-      author: {
-        id: '5',
-      },
+      mentions: { users: mockUsers },
+      author: { id: '5' },
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
@@ -33,12 +29,8 @@ describe('danhSomeone', () => {
       content: '-hit',
       reply: replyMock,
       channel: { send: replyMock },
-      mentions: {
-        users: mockUsers,
-      },
-      author: {
-        id: '1',
-      },
+      mentions: { users: mockUsers },
+      author: { id: '1' },
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
@@ -60,12 +52,8 @@ describe('danhSomeone', () => {
       content: '-hit',
       reply: replyMock,
       channel: { send: replyMock },
-      mentions: {
-        users: undefined,
-      },
-      author: {
-        id: '1',
-      },
+      mentions: { users: undefined },
+      author: { id: '1' },
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
@@ -80,9 +68,7 @@ describe('danhSomeone', () => {
       mentions: {
         users: { first: jest.fn(() => undefined) },
       },
-      author: {
-        id: '1',
-      },
+      author: { id: '1' },
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
@@ -94,9 +80,7 @@ describe('danhSomeone', () => {
       content: '-hit',
       channel: { send: replyMock },
       reply: replyMock,
-      author: {
-        id: '1',
-      },
+      author: { id: '1' },
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
@@ -108,9 +92,7 @@ describe('danhSomeone', () => {
       content: '-hit',
       channel: { send: replyMock },
       reply: replyMock,
-      author: {
-        id: '0',
-      },
+      author: { id: '0' },
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);

--- a/discord-bot/src/commands/danhSomeone/index.test.ts
+++ b/discord-bot/src/commands/danhSomeone/index.test.ts
@@ -55,13 +55,30 @@ describe('danhSomeone', () => {
     expect(replyMock.mock.calls.length).toBe(0);
   });
 
+  it('it should return if mentioned users is undefined', () => {
+    const mockMsg: any = {
+      content: '-hit',
+      reply: replyMock,
+      channel: { send: replyMock },
+      mentions: {
+        users: undefined,
+      },
+      author: {
+        id: '1',
+      },
+    };
+    const mockBotId = '0';
+    danhSomeone(mockMsg, mockBotId);
+    expect(replyMock.mock.calls.length).toBe(0);
+  });
+
   it('it should return if no user is mentioned', () => {
     const mockMsg: any = {
       content: '-hit',
       reply: replyMock,
       channel: { send: replyMock },
       mentions: {
-        users: { first: jest.fn(() => {}) },
+        users: { first: jest.fn(() => undefined) },
       },
       author: {
         id: '1',

--- a/discord-bot/src/commands/danhSomeone/index.test.ts
+++ b/discord-bot/src/commands/danhSomeone/index.test.ts
@@ -22,7 +22,7 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(4);
+    expect(replyMock).toHaveBeenCalledTimes(4);
   });
 
   it('it should not hit yourself', () => {
@@ -42,7 +42,7 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(1);
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 
   it('it should return if no keyword is mentioned', () => {
@@ -52,7 +52,7 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('it should return if mentioned users is undefined', () => {
@@ -69,7 +69,7 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('it should return if no user is mentioned', () => {
@@ -86,7 +86,7 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('should return if no user is mentioned', () => {
@@ -100,7 +100,7 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('should do nothing if bot message has keywords', () => {
@@ -114,6 +114,6 @@ describe('danhSomeone', () => {
     };
     const mockBotId = '0';
     danhSomeone(mockMsg, mockBotId);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 });

--- a/discord-bot/src/commands/danhSomeone/index.ts
+++ b/discord-bot/src/commands/danhSomeone/index.ts
@@ -2,7 +2,7 @@ import { Message } from 'discord.js';
 import { getRandomIntInclusive } from '../../utils/random';
 
 export const danhSomeone = async (msg: Message, botId: string) => {
-  if (msg.author.id === botId) return; // return if message is from a Discord bot
+  if (msg.author.id === botId) return; // return if message is from this bot
   if (!msg.mentions) return;
   if (!msg.mentions.users?.first()) return; // return if no user is mentioned
 

--- a/discord-bot/src/commands/mockSomeone/index.test.ts
+++ b/discord-bot/src/commands/mockSomeone/index.test.ts
@@ -23,9 +23,7 @@ describe('mockSomeone test', () => {
       content: `-mock`,
       channel: {
         send: replyMock,
-        messages: {
-          fetch: fetchCallback,
-        },
+        messages: { fetch: fetchCallback },
       },
     });
 

--- a/discord-bot/src/commands/mockSomeone/index.test.ts
+++ b/discord-bot/src/commands/mockSomeone/index.test.ts
@@ -15,7 +15,7 @@ describe('mockSomeone test', () => {
     };
 
     await mockSomeone(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(1);
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 
   describe('For -mock prefix with blank content', () => {
@@ -42,8 +42,8 @@ describe('mockSomeone test', () => {
       const mockMsg: any = getMockMsg(fetchMock);
 
       await mockSomeone(mockMsg);
-      expect(replyMock.mock.calls.length).toBe(0);
-      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(replyMock).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     describe('Fetching previous message', () => {
@@ -54,8 +54,8 @@ describe('mockSomeone test', () => {
         const mockMsg: any = getMockMsg(fetchMock);
 
         await mockSomeone(mockMsg);
-        expect(replyMock.mock.calls.length).toBe(0);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(replyMock).not.toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       });
 
       it('Should return blank if previous message is blank', async () => {
@@ -66,8 +66,8 @@ describe('mockSomeone test', () => {
         const mockMsg: any = getMockMsg(fetchMock);
 
         await mockSomeone(mockMsg);
-        expect(replyMock.mock.calls.length).toBe(0);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(replyMock).not.toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       });
 
       it('Should mock the previous message', async () => {
@@ -78,8 +78,8 @@ describe('mockSomeone test', () => {
         const mockMsg: any = getMockMsg(fetchMock);
 
         await mockSomeone(mockMsg);
-        expect(replyMock.mock.calls.length).toBe(1);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(replyMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -91,8 +91,8 @@ describe('mockSomeone test', () => {
         });
 
         await mockSomeone(mockMsg);
-        expect(replyMock.mock.calls.length).toBe(0);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(replyMock).not.toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       });
 
       it('Should return blank if referred message is blank', async () => {
@@ -103,8 +103,8 @@ describe('mockSomeone test', () => {
         });
 
         await mockSomeone(mockMsg);
-        expect(replyMock.mock.calls.length).toBe(0);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(replyMock).not.toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       });
 
       it('Should mock the referred message', async () => {
@@ -115,8 +115,8 @@ describe('mockSomeone test', () => {
         });
 
         await mockSomeone(mockMsg);
-        expect(replyMock.mock.calls.length).toBe(1);
-        expect(fetchMock.mock.calls.length).toBe(1);
+        expect(replyMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/discord-bot/src/commands/mockSomeone/index.test.ts
+++ b/discord-bot/src/commands/mockSomeone/index.test.ts
@@ -46,7 +46,7 @@ describe('mockSomeone test', () => {
       expect(fetchMock.mock.calls.length).toBe(1);
     });
 
-    describe('Fetching previuos message', () => {
+    describe('Fetching previous message', () => {
       it('Should throw error if previous message cannot be retrieved', async () => {
         const fetchMock = jest.fn(async () => ({
           first: () => undefined,
@@ -84,6 +84,17 @@ describe('mockSomeone test', () => {
     });
 
     describe('Fetching referred message', () => {
+      it('Should throw error if referred message cannot be fetched by id', async () => {
+        const fetchMock = jest.fn(async () => undefined);
+        const mockMsg: any = getMockMessageWithReference(fetchMock, {
+          messageID: '1234',
+        });
+
+        await mockSomeone(mockMsg);
+        expect(replyMock.mock.calls.length).toBe(0);
+        expect(fetchMock.mock.calls.length).toBe(1);
+      });
+
       it('Should return blank if referred message is blank', async () => {
         const blankMessage = { content: '' };
         const fetchMock = jest.fn(async () => blankMessage);

--- a/discord-bot/src/commands/mockSomeone/index.ts
+++ b/discord-bot/src/commands/mockSomeone/index.ts
@@ -17,7 +17,7 @@ const generateMockText = (message: string) =>
       return `${outputText}${spongeCharacter}`;
     }, '');
 
-const handleFetchMessageError = (error: any) => {
+const handleFetchMessageError = (error: Error) => {
   console.error('CANNOT FETCH MESSAGES IN CHANNEL', error);
   return '';
 };

--- a/discord-bot/src/commands/quoteOfTheDay/fetchQuote.test.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/fetchQuote.test.ts
@@ -1,3 +1,4 @@
+import faker from 'faker';
 import fetch from 'node-fetch';
 import fetchQuote from './fetchQuote';
 
@@ -22,10 +23,11 @@ describe('Fetching quotes', () => {
   });
 
   it('Should return the quote when it finally got it', async () => {
+    const fakeQuote = faker.lorem.words(25);
     const sampleQuote = {
-      q: 'This is a quote',
+      q: fakeQuote,
       a: 'Author',
-      h: '<h1>This is a quote</h1>',
+      h: `<h1>${fakeQuote}</h1>`,
     };
     const mockedQuote: any = {
       json: async () => [sampleQuote],

--- a/discord-bot/src/commands/quoteOfTheDay/fetchQuote.test.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/fetchQuote.test.ts
@@ -14,9 +14,7 @@ describe('Fetching quotes', () => {
   });
 
   it('Should return undefined if it downloaded a blank array', async () => {
-    const mockedQuote: any = {
-      json: async () => [],
-    };
+    const mockedQuote: any = { json: async () => [] };
     mockFetch.mockImplementationOnce(async () => mockedQuote);
     const output = await fetchQuote();
     expect(output).toEqual(undefined);
@@ -29,9 +27,7 @@ describe('Fetching quotes', () => {
       a: 'Author',
       h: `<h1>${fakeQuote}</h1>`,
     };
-    const mockedQuote: any = {
-      json: async () => [sampleQuote],
-    };
+    const mockedQuote: any = { json: async () => [sampleQuote] };
     mockFetch.mockImplementationOnce(async () => mockedQuote);
     const output = await fetchQuote();
     expect(output).toEqual({

--- a/discord-bot/src/commands/quoteOfTheDay/fetchQuote.test.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/fetchQuote.test.ts
@@ -1,0 +1,41 @@
+import fetch from 'node-fetch';
+import fetchQuote from './fetchQuote';
+
+jest.mock('node-fetch');
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+describe('Fetching quotes', () => {
+  it('Should return undefined if it cannot get a quote', async () => {
+    const mockedQuote: any = undefined;
+    mockFetch.mockImplementationOnce(async () => mockedQuote);
+    const output = await fetchQuote();
+    expect(output).toEqual(undefined);
+  });
+
+  it('Should return undefined if it downloaded a blank array', async () => {
+    const mockedQuote: any = {
+      json: async () => [],
+    };
+    mockFetch.mockImplementationOnce(async () => mockedQuote);
+    const output = await fetchQuote();
+    expect(output).toEqual(undefined);
+  });
+
+  it('Should return the quote when it finally got it', async () => {
+    const sampleQuote = {
+      q: 'This is a quote',
+      a: 'Author',
+      h: '<h1>This is a quote</h1>',
+    };
+    const mockedQuote: any = {
+      json: async () => [sampleQuote],
+    };
+    mockFetch.mockImplementationOnce(async () => mockedQuote);
+    const output = await fetchQuote();
+    expect(output).toEqual({
+      quote: sampleQuote.q,
+      author: sampleQuote.a,
+      html: sampleQuote.h,
+    });
+  });
+});

--- a/discord-bot/src/commands/quoteOfTheDay/fetchQuote.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/fetchQuote.ts
@@ -1,0 +1,35 @@
+import fetch from 'node-fetch';
+
+interface ZenQuote {
+  q: string;
+  a: string;
+  h: string;
+}
+
+export interface Quote {
+  quote: string;
+  author: string;
+  html: string;
+}
+
+const ZEN_QUOTES_URL =
+  'https://zenquotes.io/api/random/6a874c704a11dea9305fe58e145d51c218f9f143';
+
+const fetchQuote = async (): Promise<Quote | undefined> => {
+  try {
+    const response = await fetch(ZEN_QUOTES_URL); // download quotes from this site
+    const body: ZenQuote[] = await response.json();
+    if (body.length === 0) throw new Error('No quote downloaded');
+
+    const { q, a, h } = body[0];
+    return {
+      quote: q,
+      author: a,
+      html: h,
+    };
+  } catch (error) {
+    console.error('THERE IS AN ERROR DOWNLOADING QUOTES', error);
+  }
+};
+
+export default fetchQuote;

--- a/discord-bot/src/commands/quoteOfTheDay/index.test.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/index.test.ts
@@ -1,4 +1,8 @@
 import getQuoteOfTheDay from '.';
+import fetchQuote from './fetchQuote';
+
+jest.mock('./fetchQuote');
+const mockFetch = fetchQuote as jest.MockedFunction<typeof fetchQuote>;
 
 const replyMock = jest.fn(() => {});
 
@@ -19,7 +23,23 @@ describe('Get quote of the day test', () => {
       channel: { send: replyMock },
       author: { bot: false },
     };
+    mockFetch.mockImplementationOnce(async () => ({
+      quote: 'This is a quote',
+      author: 'Author',
+      html: '<h1>This is a quote</h1>',
+    }));
     await getQuoteOfTheDay(mockMsg);
     expect(replyMock.mock.calls.length).toBe(1);
+  });
+
+  it('Should return if no quote can be downloaded', async () => {
+    const mockMsg: any = {
+      content: `-qotd`,
+      channel: { send: replyMock },
+      author: { bot: false },
+    };
+    mockFetch.mockImplementationOnce(async () => undefined);
+    await getQuoteOfTheDay(mockMsg);
+    expect(replyMock.mock.calls.length).toBe(0);
   });
 });

--- a/discord-bot/src/commands/quoteOfTheDay/index.test.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/index.test.ts
@@ -1,3 +1,4 @@
+import faker from 'faker';
 import getQuoteOfTheDay from '.';
 import fetchQuote from './fetchQuote';
 
@@ -23,10 +24,11 @@ describe('Get quote of the day test', () => {
       channel: { send: replyMock },
       author: { bot: false },
     };
+    const fakeQuote = faker.lorem.words(25);
     mockFetch.mockImplementationOnce(async () => ({
-      quote: 'This is a quote',
+      quote: fakeQuote,
       author: 'Author',
-      html: '<h1>This is a quote</h1>',
+      html: `<h1>${fakeQuote}</h1>`,
     }));
     await getQuoteOfTheDay(mockMsg);
     expect(replyMock.mock.calls.length).toBe(1);

--- a/discord-bot/src/commands/quoteOfTheDay/index.test.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/index.test.ts
@@ -15,7 +15,7 @@ describe('Get quote of the day test', () => {
       author: { bot: true },
     };
     await getQuoteOfTheDay(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('Should return a random quote if somebody sends the prefix', async () => {
@@ -31,7 +31,7 @@ describe('Get quote of the day test', () => {
       html: `<h1>${fakeQuote}</h1>`,
     }));
     await getQuoteOfTheDay(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(1);
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 
   it('Should return if no quote can be downloaded', async () => {
@@ -42,6 +42,6 @@ describe('Get quote of the day test', () => {
     };
     mockFetch.mockImplementationOnce(async () => undefined);
     await getQuoteOfTheDay(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 });

--- a/discord-bot/src/commands/quoteOfTheDay/index.ts
+++ b/discord-bot/src/commands/quoteOfTheDay/index.ts
@@ -1,26 +1,16 @@
 import { Message } from 'discord.js';
-import fetch from 'node-fetch';
-
-interface Quote {
-  q: string;
-  a: string;
-  h: string;
-}
+import fetchQuote from './fetchQuote';
 
 const getQuoteOfTheDay = async ({ channel, author }: Message) => {
   if (author.bot) return; // return if bot sends the command
+  const quote = await fetchQuote();
+  if (!quote) return;
 
-  const response = await fetch(
-    'https://zenquotes.io/api/random/6a874c704a11dea9305fe58e145d51c218f9f143'
-  ); // download quotes from this site
-  const body: Quote[] = await response.json();
-  if (body.length === 0) return; // return if no quote is downloaded
-  const quote = body[0];
   channel.send({
     embed: {
       color: 0x0072a8,
-      title: quote.q,
-      description: `- ${quote.a} -`,
+      title: quote.quote,
+      description: `- ${quote.author} -`,
       author: {
         name: `Quote of the day`,
       },

--- a/discord-bot/src/commands/thanks/checkReputation.test.ts
+++ b/discord-bot/src/commands/thanks/checkReputation.test.ts
@@ -1,9 +1,10 @@
 import { checkReputation } from './checkReputation';
 import { getPrismaClient } from '../../clients/prisma';
 
-jest.mock('../../clients/prisma', () => ({
-  getPrismaClient: jest.fn(),
-}));
+jest.mock('../../clients/prisma');
+const mockGetPrismaClient = getPrismaClient as jest.MockedFunction<
+  typeof getPrismaClient
+>;
 
 const replyMock = jest.fn(() => {});
 const findUniqueMock = jest.fn(() => ({ id: '1' }));
@@ -16,9 +17,10 @@ describe('checkReputation', () => {
       reply: replyMock,
     };
 
-    (getPrismaClient as jest.Mock).mockReturnValue({
+    const mockPrismaClient: any = {
       user: { findUnique: findUniqueMock },
-    });
+    };
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await checkReputation(messageMock);
 

--- a/discord-bot/src/commands/thanks/checkReputation.test.ts
+++ b/discord-bot/src/commands/thanks/checkReputation.test.ts
@@ -24,7 +24,7 @@ describe('checkReputation', () => {
 
     await checkReputation(messageMock);
 
-    expect(findUniqueMock.mock.calls.length).toBe(1);
-    expect(replyMock.mock.calls.length).toBe(1);
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/discord-bot/src/commands/thanks/thankUser.test.ts
+++ b/discord-bot/src/commands/thanks/thankUser.test.ts
@@ -17,8 +17,8 @@ describe('thankUser', () => {
 
   it('should do nothing if mentions more than one user', async () => {
     const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '0' } as any);
-    mockUsers.set('1', { id: '1' } as any);
+    mockUsers.set('0', { id: '0' } as User);
+    mockUsers.set('1', { id: '1' } as User);
 
     const mockMsg: any = {
       content: 'thank',
@@ -39,7 +39,7 @@ describe('thankUser', () => {
 
   it('should do nothing if user mention himself', async () => {
     const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '0' } as any);
+    mockUsers.set('0', { id: '0' } as User);
 
     const mockMsg: any = {
       content: 'thank',
@@ -130,7 +130,7 @@ describe('thankUser', () => {
 
   it('should call reply', async () => {
     const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '0' } as any);
+    mockUsers.set('0', { id: '0' } as User);
 
     const mockMsg: any = {
       content: 'thank',

--- a/discord-bot/src/commands/thanks/thankUser.test.ts
+++ b/discord-bot/src/commands/thanks/thankUser.test.ts
@@ -63,6 +63,44 @@ describe('thankUser', () => {
     expect(replyMock.mock.calls.length).toBe(0);
   });
 
+  it('should do nothing if user mention no one', async () => {
+    const mockUsers = new Collection<string, User>();
+    mockUsers.set('0', { id: '0' } as User);
+
+    const mockMsg: any = {
+      content: 'thank',
+      reply: replyMock,
+      mentions: {
+        users: {
+          first: () => undefined,
+          size: 1,
+        },
+      },
+      author: {
+        id: '5',
+        bot: false,
+      },
+    };
+
+    const mockPrismaClient: any = {
+      user: {
+        findUnique: findUniqueMock,
+        update: updateUserMock,
+      },
+      reputationLog: {
+        create: reputationCreateMock,
+      },
+      $transaction: transactionMock,
+    };
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
+
+    await thankUser(mockMsg);
+    expect(findUniqueMock.mock.calls.length).toBe(0);
+    expect(replyMock.mock.calls.length).toBe(0);
+    expect(reputationCreateMock.mock.calls.length).toBe(0);
+    expect(transactionMock.mock.calls.length).toBe(0);
+  });
+
   it('should do nothing if bot is mentioned', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '1', bot: true } as User);

--- a/discord-bot/src/commands/thanks/thankUser.test.ts
+++ b/discord-bot/src/commands/thanks/thankUser.test.ts
@@ -2,9 +2,10 @@ import { Collection, User } from 'discord.js';
 import { thankUser } from './thankUser';
 import { getPrismaClient } from '../../clients/prisma';
 
-jest.mock('../../clients/prisma', () => ({
-  getPrismaClient: jest.fn(),
-}));
+jest.mock('../../clients/prisma');
+const mockGetPrismaClient = getPrismaClient as jest.MockedFunction<
+  typeof getPrismaClient
+>;
 
 const replyMock = jest.fn(() => {});
 
@@ -13,7 +14,6 @@ describe('thankUser', () => {
   const updateUserMock = jest.fn();
   const reputationCreateMock = jest.fn();
   const transactionMock = jest.fn(() => [{ id: 0 }]);
-  (getPrismaClient as jest.Mock).mockReturnValue({});
 
   it('should do nothing if mentions more than one user', async () => {
     const mockUsers = new Collection<string, User>();
@@ -30,7 +30,9 @@ describe('thankUser', () => {
         bot: false,
       },
     };
-    (getPrismaClient as jest.Mock).mockReturnValue({});
+
+    const mockPrismaClient: any = {};
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
 
@@ -53,7 +55,8 @@ describe('thankUser', () => {
       },
     };
 
-    (getPrismaClient as jest.Mock).mockReturnValue({});
+    const mockPrismaClient: any = {};
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
 
@@ -76,7 +79,7 @@ describe('thankUser', () => {
       },
     };
 
-    (getPrismaClient as jest.Mock).mockReturnValue({
+    const mockPrismaClient: any = {
       user: {
         findUnique: findUniqueMock,
         update: updateUserMock,
@@ -85,7 +88,8 @@ describe('thankUser', () => {
         create: reputationCreateMock,
       },
       $transaction: transactionMock,
-    });
+    };
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
     expect(findUniqueMock.mock.calls.length).toBe(0);
@@ -110,7 +114,7 @@ describe('thankUser', () => {
       },
     };
 
-    (getPrismaClient as jest.Mock).mockReturnValue({
+    const mockPrismaClient: any = {
       user: {
         findUnique: findUniqueMock,
         update: updateUserMock,
@@ -119,7 +123,8 @@ describe('thankUser', () => {
         create: reputationCreateMock,
       },
       $transaction: transactionMock,
-    });
+    };
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
     expect(findUniqueMock.mock.calls.length).toBe(0);
@@ -143,7 +148,7 @@ describe('thankUser', () => {
       },
     };
 
-    (getPrismaClient as jest.Mock).mockReturnValue({
+    const mockPrismaClient: any = {
       user: {
         findUnique: findUniqueMock,
         update: updateUserMock,
@@ -152,7 +157,8 @@ describe('thankUser', () => {
         create: reputationCreateMock,
       },
       $transaction: transactionMock,
-    });
+    };
+    mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
 

--- a/discord-bot/src/commands/thanks/thankUser.test.ts
+++ b/discord-bot/src/commands/thanks/thankUser.test.ts
@@ -36,7 +36,7 @@ describe('thankUser', () => {
 
     await thankUser(mockMsg);
 
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('should do nothing if user mention himself', async () => {
@@ -60,7 +60,7 @@ describe('thankUser', () => {
 
     await thankUser(mockMsg);
 
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(replyMock).not.toHaveBeenCalled();
   });
 
   it('should do nothing if user mention no one', async () => {
@@ -95,10 +95,10 @@ describe('thankUser', () => {
     mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
-    expect(findUniqueMock.mock.calls.length).toBe(0);
-    expect(replyMock.mock.calls.length).toBe(0);
-    expect(reputationCreateMock.mock.calls.length).toBe(0);
-    expect(transactionMock.mock.calls.length).toBe(0);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(reputationCreateMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
   });
 
   it('should do nothing if bot is mentioned', async () => {
@@ -130,10 +130,10 @@ describe('thankUser', () => {
     mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
-    expect(findUniqueMock.mock.calls.length).toBe(0);
-    expect(replyMock.mock.calls.length).toBe(0);
-    expect(reputationCreateMock.mock.calls.length).toBe(0);
-    expect(transactionMock.mock.calls.length).toBe(0);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(reputationCreateMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
   });
 
   it('should do nothing if bot is saying the keywords', async () => {
@@ -165,10 +165,10 @@ describe('thankUser', () => {
     mockGetPrismaClient.mockReturnValue(mockPrismaClient);
 
     await thankUser(mockMsg);
-    expect(findUniqueMock.mock.calls.length).toBe(0);
-    expect(replyMock.mock.calls.length).toBe(0);
-    expect(reputationCreateMock.mock.calls.length).toBe(0);
-    expect(transactionMock.mock.calls.length).toBe(0);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(reputationCreateMock).not.toHaveBeenCalled();
+    expect(transactionMock).not.toHaveBeenCalled();
   });
 
   it('should call reply', async () => {
@@ -200,10 +200,10 @@ describe('thankUser', () => {
 
     await thankUser(mockMsg);
 
-    expect(findUniqueMock.mock.calls.length).toBe(1);
-    expect(updateUserMock.mock.calls.length).toBe(1);
-    expect(reputationCreateMock.mock.calls.length).toBe(1);
-    expect(transactionMock.mock.calls.length).toBe(1);
-    expect(replyMock.mock.calls.length).toBe(1);
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+    expect(updateUserMock).toHaveBeenCalledTimes(1);
+    expect(reputationCreateMock).toHaveBeenCalledTimes(1);
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(replyMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/discord-bot/src/config.ts
+++ b/discord-bot/src/config.ts
@@ -1,4 +1,4 @@
-import { Client } from 'discord.js';
+import { ClientUser } from 'discord.js';
 import { CommandConfig } from './utils/messageProcessor';
 
 import ask8Ball from './commands/8ball';
@@ -7,7 +7,7 @@ import mockSomeone from './commands/mockSomeone';
 import { thankUser, checkReputation } from './commands/thanks';
 import getQuoteOfTheDay from './commands/quoteOfTheDay';
 
-export const getConfigs = (client: Client): CommandConfig => ({
+export const getConfigs = (botUser: ClientUser): CommandConfig => ({
   prefixedCommands: {
     prefix: '-',
     commands: [
@@ -16,7 +16,7 @@ export const getConfigs = (client: Client): CommandConfig => ({
       { matcher: 'mock', fn: mockSomeone },
       {
         matcher: 'hit',
-        fn: (message) => danhSomeone(message, (client.user as any).id),
+        fn: (message) => danhSomeone(message, botUser.id),
       },
       { matcher: 'qotd', fn: getQuoteOfTheDay },
     ],

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -9,7 +9,7 @@ getDiscordClient({
   if (!client.user) throw new Error('Something went wrong!');
   console.log(`Logged in as ${client.user.tag}!`);
 
-  const configs = getConfigs(client);
+  const configs = getConfigs(client.user);
   client.on('message', (msg) => processMessage(msg, configs));
 });
 


### PR DESCRIPTION
# Goals

The main goals for this PRs are:

- Removing `any` type coercion in our main function codes, and keep the `any` type only in tests.
- If there are any type in test files that can be certained (as which type from Discord lib or Prisma, etc.), keep it that way instead of `as any`.
- Finish test case coverage for all existing modules.

# What is done

- Pass only the bot user to the config
- Replace any type assertion in tests and throwing errors
- Finish test case coverages for mockSomeone and danhSomeone module
- Split fetchQuote into a separate function and add test cases for that too, completing the coverage
- Replace the `(getPrismaClient as jest.Mock)` with a proper `mockGetPrismaClient = getPrimaClient as jest.MockedFunction<typeof getPrismaClient>`.
- Replace all `mockFunc.calls.length).toBe(1)` matcher with Jest's native matcher `toHaveBeenCalled()` and `toHaveBeenCalledTimes(number)`.