### PR TITLE
Replicate NQN bot function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Developers should add to the **Unreleased** section once they feel their branch 
 - Added reps, thanks, "đánh" features
 - Added mock someone feature
 - Added ask 8ball (-8ball) and quote of the day (-qotd) feature
+- Added animated emoji for non Nitro user
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Developers should add to the **Unreleased** section once they feel their branch 
 - Added mock someone feature
 - Added ask 8ball (-8ball) and quote of the day (-qotd) feature
 - Added animated emoji for non Nitro user
+- Added embed message function when user paste in a URL of another message
 
 ### Changed
 

--- a/discord-bot/src/commands/animatedEmoji/index.test.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.test.ts
@@ -8,9 +8,11 @@ const fakeHook: any = {
   channelID: '123',
   send: webhookSendMock,
 };
-const fakeEmoji: any = {
+const fakeAnimatedEmoji: any = {
   name: 'sadparrot',
+  animated: true,
 };
+
 const fakeWebhooks = new Collection<string, Webhook>();
 fakeWebhooks.set('0', fakeHook);
 
@@ -25,11 +27,12 @@ describe('animated emoji test', () => {
       channel: {
         fetchWebhooks: async () => fakeWebhooks,
         createWebhook: async () => fakeHook,
+        id: '123',
       },
       guild: {
         emojis: {
           cache: {
-            find: () => fakeEmoji,
+            find: () => fakeAnimatedEmoji,
           },
         },
       },
@@ -51,15 +54,38 @@ describe('animated emoji test', () => {
       guild: {
         emojis: {
           cache: {
-            find: () => fakeEmoji,
+            find: () => fakeAnimatedEmoji,
           },
         },
       },
-      delete: () => msgDeleteMock,
+      delete: msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
-    expect(webhookSendMock).toHaveBeenCalledTimes(0);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+  });
+
+  it('Should return if author has nitro', async () => {
+    const fetchHookMock = jest.fn(() => {});
+    const mockMsg: any = {
+      content: `Hello <a:sadparrot:123121233>`,
+      author: { bot: false },
+      channel: {
+        fetchWebhooks: async () => fetchHookMock(),
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        emojis: {
+          cache: {
+            find: () => fakeAnimatedEmoji,
+          },
+        },
+      },
+      delete: msgDeleteMock,
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(fetchHookMock).not.toHaveBeenCalled();
   });
 
   it('Should create a webhook if nothing found', async () => {
@@ -74,20 +100,20 @@ describe('animated emoji test', () => {
       guild: {
         emojis: {
           cache: {
-            find: () => fakeEmoji,
+            find: () => fakeAnimatedEmoji,
           },
         },
       },
-      delete: () => msgDeleteMock,
+      delete: msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
     expect(createHookMock).toHaveBeenCalledTimes(1);
   });
 
-  it('Should return if no emoji is found', async () => {
+  it('Should return if no matching emoji is found on server', async () => {
     const mockMsg: any = {
-      content: `:invalid:`,
+      content: `:not-emoji:`,
       author: {
         bot: false,
         avatarURL: () => jest.fn(() => {}),
@@ -99,16 +125,16 @@ describe('animated emoji test', () => {
       guild: {
         emojis: {
           cache: {
-            find: () => fakeEmoji,
+            find: () => fakeAnimatedEmoji,
           },
         },
       },
-      delete: () => msgDeleteMock,
+      delete: msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
-    expect(webhookSendMock).toHaveBeenCalled();
-    expect(msgDeleteMock).toHaveBeenCalledTimes(0);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
   });
 
   it('Should return if no emoji name is found in content', async () => {
@@ -125,15 +151,15 @@ describe('animated emoji test', () => {
       guild: {
         emojis: {
           cache: {
-            find: () => fakeEmoji,
+            find: () => fakeAnimatedEmoji,
           },
         },
       },
-      delete: () => msgDeleteMock,
+      delete: msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
-    expect(webhookSendMock).toHaveBeenCalledTimes(0);
-    expect(msgDeleteMock).toHaveBeenCalledTimes(0);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
   });
 });

--- a/discord-bot/src/commands/animatedEmoji/index.test.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.test.ts
@@ -1,46 +1,139 @@
-// import { Collection, Webhook } from 'discord.js';
+import { Collection, Webhook } from 'discord.js';
 import animatedEmoji from '.';
 
-const replyMock = jest.fn(() => {});
-describe('animated emoji test', () => {
-  /* it('Should return a message with embeded animated emoji', async () => {
-    const fakeHook = { name: 'Jkiller-hook', guildID: '123' };
-    const fakeWebhooks = new Collection<string, Webhook>();
-    fakeWebhooks.set('0', fakeHook);
-    const mockMsg: any = {
-      guild: {
-        fetchWebHooks: async () => fakeWebhooks,
-      }
-    }
+const webhookSendMock = jest.fn(() => {});
+const msgDeleteMock = jest.fn(() => {});
+const fakeHook: any = {
+  name: 'VAIT-Hook',
+  channelID: '123',
+  send: webhookSendMock,
+};
+const fakeEmoji: any = {
+  name: 'sadparrot',
+};
+const fakeWebhooks = new Collection<string, Webhook>();
+fakeWebhooks.set('0', fakeHook);
 
+describe('animated emoji test', () => {
+  it('Should return a message with embeded animated emoji', async () => {
+    const mockMsg: any = {
+      content: ':sadparrot:',
+      author: {
+        bot: false,
+        avatarURL: () => jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        emojis: {
+          cache: {
+            find: () => fakeEmoji,
+          },
+        },
+      },
+      delete: msgDeleteMock,
+    };
     await animatedEmoji(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(1);
-  }); */
+    expect(webhookSendMock).toHaveBeenCalledTimes(1);
+    expect(msgDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
   it('Should return if author is a bot', async () => {
     const mockMsg: any = {
       content: `:sadparrot:`,
       author: { bot: true },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        emojis: {
+          cache: {
+            find: () => fakeEmoji,
+          },
+        },
+      },
+      delete: () => msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(webhookSendMock).toHaveBeenCalledTimes(0);
   });
+
+  it('Should create a webhook if nothing found', async () => {
+    const createHookMock = jest.fn(() => {});
+    const mockMsg: any = {
+      content: `:sadparrot:`,
+      author: { bot: false },
+      channel: {
+        fetchWebhooks: async () => new Collection<string, Webhook>(),
+        createWebhook: createHookMock,
+      },
+      guild: {
+        emojis: {
+          cache: {
+            find: () => fakeEmoji,
+          },
+        },
+      },
+      delete: () => msgDeleteMock,
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(createHookMock).toHaveBeenCalledTimes(1);
+  });
+
   it('Should return if no emoji is found', async () => {
     const mockMsg: any = {
       content: `:invalid:`,
-      author: { bot: false },
+      author: {
+        bot: false,
+        avatarURL: () => jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        emojis: {
+          cache: {
+            find: () => fakeEmoji,
+          },
+        },
+      },
+      delete: () => msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(webhookSendMock).toHaveBeenCalled();
+    expect(msgDeleteMock).toHaveBeenCalledTimes(0);
   });
+
   it('Should return if no emoji name is found in content', async () => {
     const mockMsg: any = {
       content: `abcasd`,
-      author: { bot: false },
+      author: {
+        bot: false,
+        avatarURL: () => jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        emojis: {
+          cache: {
+            find: () => fakeEmoji,
+          },
+        },
+      },
+      delete: () => msgDeleteMock,
     };
 
     await animatedEmoji(mockMsg);
-    expect(replyMock.mock.calls.length).toBe(0);
+    expect(webhookSendMock).toHaveBeenCalledTimes(0);
+    expect(msgDeleteMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/discord-bot/src/commands/animatedEmoji/index.test.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.test.ts
@@ -1,16 +1,21 @@
+// import { Collection, Webhook } from 'discord.js';
 import animatedEmoji from '.';
 
 const replyMock = jest.fn(() => {});
 describe('animated emoji test', () => {
-  it('Should return a message with embeded animated emoji', async () => {
+  /* it('Should return a message with embeded animated emoji', async () => {
+    const fakeHook = { name: 'Jkiller-hook', guildID: '123' };
+    const fakeWebhooks = new Collection<string, Webhook>();
+    fakeWebhooks.set('0', fakeHook);
     const mockMsg: any = {
-      content: `:sadparrot:`,
-      author: { bot: false },
-    };
+      guild: {
+        fetchWebHooks: async () => fakeWebhooks,
+      }
+    }
 
     await animatedEmoji(mockMsg);
     expect(replyMock.mock.calls.length).toBe(1);
-  });
+  }); */
   it('Should return if author is a bot', async () => {
     const mockMsg: any = {
       content: `:sadparrot:`,
@@ -22,7 +27,16 @@ describe('animated emoji test', () => {
   });
   it('Should return if no emoji is found', async () => {
     const mockMsg: any = {
-      content: `sadparrot`,
+      content: `:invalid:`,
+      author: { bot: false },
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(replyMock.mock.calls.length).toBe(0);
+  });
+  it('Should return if no emoji name is found in content', async () => {
+    const mockMsg: any = {
+      content: `abcasd`,
       author: { bot: false },
     };
 

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -1,40 +1,40 @@
-import { Message } from 'discord.js';
+import { Message, TextChannel, Webhook } from 'discord.js';
 
 const animatedEmoji = async (msg: Message) => {
-  const { author, content, guild } = msg;
+  const { author, content, guild, channel } = msg;
   if (author.bot) return; // return if bot sends the message
+
   const emojiRegex = '(:.+:)+';
   const matches = content.match(emojiRegex);
-  if (matches && matches.length < 1) return;
-  const emojis = content.split(':').filter((e) => e !== '');
-  if (emojis) {
-    let message = content;
-    emojis.forEach((emoji) => {
-      const emoteName = emoji.replace(/:/gi, '');
-      const emote = guild?.emojis.cache.find(({ name }) => name === emoteName);
-      if (emote) {
-        message = message.replace(
-          new RegExp(`:${emoji}:`, 'gi'),
-          emote.animated
-            ? `<a:${emote.name}:${emote.id}>`
-            : `<${emote.name}:${emote.id}>`
-        ); // replace emoji name in the message with the actual emoji syntax
-      }
-    });
+  if (matches && matches.length < 1) return; // return if no emoji name found
 
-    const sendMess = guild?.fetchWebhooks().then((value) => {
-      const webhook = value.find(
-        ({ name, guildID }) => name === 'Jkiller-Hook' && guildID === guild.id
-      );
-      if (!webhook) return; // return if no webhook installed
-      msg.delete();
-      return webhook.send(message, {
-        username: author.username,
-        avatarURL: author.avatarURL() || undefined,
-      });
-    });
-    return sendMess;
+  let webhook = (await (channel as TextChannel).fetchWebhooks()).find(
+    ({ name, channelID }) => name === 'Jkiller-Hook' && channelID === channel.id
+  );
+
+  if (!webhook) {
+    // create webhook if not found
+    webhook = await (channel as TextChannel).createWebhook('Jkiller-Hook');
   }
-};
+  if (!webhook) return; // return if can't find or create webhook
 
+  let message = content;
+  const emojis = content.split(':').filter((e) => e !== '');
+  emojis.forEach((emoji) => {
+    const emoteName = emoji.replace(/:/gi, '');
+    const emote = guild?.emojis.cache.find(({ name }) => name === emoteName);
+    if (!emote) return; // return if no matching emoji found on server
+    message = message.replace(
+      new RegExp(`:${emoji}:`, 'gi'),
+      emote.animated
+        ? `<a:${emote.name}:${emote.id}>`
+        : `<${emote.name}:${emote.id}>`
+    ); // replace emoji name in the message with the actual emoji syntax
+  });
+  (webhook as Webhook).send(message, {
+    username: author.username,
+    avatarURL: author.avatarURL() ?? undefined,
+  });
+  msg.delete();
+};
 export default animatedEmoji;

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -1,0 +1,40 @@
+import { Message } from 'discord.js';
+
+const animatedEmoji = async (msg: Message) => {
+  const { author, content, guild } = msg;
+  if (author.bot) return; // return if bot sends the message
+  const emojiRegex = '(:.+:)+';
+  const matches = content.match(emojiRegex);
+  if (matches && matches.length < 1) return;
+  const emojis = content.split(':').filter((e) => e !== '');
+  if (emojis) {
+    let message = content;
+    emojis.forEach((emoji) => {
+      const emoteName = emoji.replace(/:/gi, '');
+      const emote = guild?.emojis.cache.find(({ name }) => name === emoteName);
+      if (emote) {
+        message = message.replace(
+          new RegExp(`:${emoji}:`, 'gi'),
+          emote.animated
+            ? `<a:${emote.name}:${emote.id}>`
+            : `<${emote.name}:${emote.id}>`
+        ); // replace emoji name in the message with the actual emoji syntax
+      }
+    });
+
+    const sendMess = guild?.fetchWebhooks().then((value) => {
+      const webhook = value.find(
+        ({ name, guildID }) => name === 'Jkiller-Hook' && guildID === guild.id
+      );
+      if (!webhook) return; // return if no webhook installed
+      msg.delete();
+      return webhook.send(message, {
+        username: author.username,
+        avatarURL: author.avatarURL() || undefined,
+      });
+    });
+    return sendMess;
+  }
+};
+
+export default animatedEmoji;

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -22,7 +22,6 @@ const animatedEmoji = async (originalMessage: Message) => {
 
   let newMessage = content;
   const emojis = content.split(':').filter((e) => e !== '');
-  console.log(`emoji: ${emojis}`);
   let emojiCount = 0;
   emojis.forEach((emoji) => {
     const emoteName = emoji.replace(/:/gim, '');

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -2,11 +2,17 @@ import { Message, TextChannel } from 'discord.js';
 
 const animatedEmoji = async (originalMessage: Message) => {
   const { author, content, guild, channel } = originalMessage;
+
   if (author.bot) return; // return if bot sends the message
 
-  const emojiRegex = '(:.+:)+';
-  const matches = content.match(emojiRegex);
-  if (!matches) return; // return if no match
+  const nitroRegex = /<a?:.+:\d+>/gim;
+  const hasNitro = content.match(nitroRegex);
+  if (hasNitro) return; // return if author has nitro
+
+  const emojiRegex = new RegExp('(:.+:)+', 'gi');
+  const hasEmoji = content.match(emojiRegex);
+  if (!hasEmoji) return; // return if no emoji found
+
   const textChannel = channel as TextChannel;
   const webHooks = await textChannel.fetchWebhooks();
   let webhook = webHooks.find(
@@ -20,11 +26,15 @@ const animatedEmoji = async (originalMessage: Message) => {
 
   let newMessage = content;
   const emojis = content.split(':').filter((e) => e !== '');
+  console.log(`emoji: ${emojis}`);
   let emojiCount = 0;
   emojis.forEach((emoji) => {
-    const emoteName = emoji.replace(/:/gi, '');
+    const emoteName = emoji.replace(/:/gim, '');
     const emote = guild?.emojis.cache.find(({ name }) => name === emoteName);
     if (!emote) return; // return if no matching emoji found on server
+    if (!emote.animated) return; // return if emoji is not animated
+    if (emote?.name !== emoteName) return; // return if doesn't match emoji's name
+
     newMessage = newMessage.replace(
       new RegExp(`:${emoji}:`, 'gi'),
       emote.animated
@@ -33,7 +43,9 @@ const animatedEmoji = async (originalMessage: Message) => {
     ); // replace emoji name in the message with the actual emoji syntax
     emojiCount += 1;
   });
+
   if (emojiCount === 0) return; // return if no emoji found
+
   try {
     await webhook.send(newMessage, {
       username: author.username,

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -1,4 +1,5 @@
-import { Message, TextChannel } from 'discord.js';
+import { Message } from 'discord.js';
+import { fetchWebhook, createWebhook } from '../../utils/webhookProcessor';
 
 const animatedEmoji = async (originalMessage: Message) => {
   const { author, content, guild, channel } = originalMessage;
@@ -13,14 +14,9 @@ const animatedEmoji = async (originalMessage: Message) => {
   const hasEmoji = content.match(emojiRegex);
   if (!hasEmoji) return; // return if no emoji found
 
-  const textChannel = channel as TextChannel;
-  const webHooks = await textChannel.fetchWebhooks();
-  let webhook = webHooks.find(
-    ({ name, channelID }) => name === 'VAIT-Hook' && channelID === channel.id
-  );
-
+  let webhook = await fetchWebhook(channel);
   if (!webhook) {
-    webhook = await textChannel.createWebhook('VAIT-Hook'); // create webhook if not found
+    webhook = await createWebhook(channel); // create webhook if not found
   }
   if (!webhook) return; // return if can't find or create webhook
 
@@ -37,9 +33,7 @@ const animatedEmoji = async (originalMessage: Message) => {
 
     newMessage = newMessage.replace(
       new RegExp(`:${emoji}:`, 'gi'),
-      emote.animated
-        ? `<a:${emote.name}:${emote.id}>`
-        : `<${emote.name}:${emote.id}>`
+      `<a:${emote.name}:${emote.id}>`
     ); // replace emoji name in the message with the actual emoji syntax
     emojiCount += 1;
   });

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, TextChannel } from 'discord.js';
 import { fetchWebhook, createWebhook } from '../../utils/webhookProcessor';
 
 const animatedEmoji = async (originalMessage: Message) => {
@@ -13,10 +13,10 @@ const animatedEmoji = async (originalMessage: Message) => {
   const emojiRegex = new RegExp('(:.+:)+', 'gi');
   const hasEmoji = content.match(emojiRegex);
   if (!hasEmoji) return; // return if no emoji found
-
-  let webhook = await fetchWebhook(channel);
+  const textChannel = channel as TextChannel;
+  let webhook = await fetchWebhook(textChannel);
   if (!webhook) {
-    webhook = await createWebhook(channel); // create webhook if not found
+    webhook = await createWebhook(textChannel); // create webhook if not found
   }
   if (!webhook) return; // return if can't find or create webhook
 

--- a/discord-bot/src/commands/animatedEmoji/intext.test.ts
+++ b/discord-bot/src/commands/animatedEmoji/intext.test.ts
@@ -1,0 +1,32 @@
+import animatedEmoji from '.';
+
+const replyMock = jest.fn(() => {});
+describe('animated emoji test', () => {
+  it('Should return a message with embeded animated emoji', async () => {
+    const mockMsg: any = {
+      content: `:sadparrot:`,
+      author: { bot: false },
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(replyMock.mock.calls.length).toBe(1);
+  });
+  it('Should return if author is a bot', async () => {
+    const mockMsg: any = {
+      content: `:sadparrot:`,
+      author: { bot: true },
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(replyMock.mock.calls.length).toBe(0);
+  });
+  it('Should return if no emoji is found', async () => {
+    const mockMsg: any = {
+      content: `sadparrot`,
+      author: { bot: false },
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(replyMock.mock.calls.length).toBe(0);
+  });
+});

--- a/discord-bot/src/commands/embedLink/index.test.ts
+++ b/discord-bot/src/commands/embedLink/index.test.ts
@@ -1,0 +1,89 @@
+import { Collection, Webhook } from 'discord.js';
+import embedLink from '.';
+
+const webhookSendMock = jest.fn(() => {});
+const msgDeleteMock = jest.fn(() => {});
+const fakeHook: any = {
+  name: 'VAIT-Hook',
+  channelID: '123',
+  send: webhookSendMock,
+};
+const fakeWebhooks = new Collection<string, Webhook>();
+fakeWebhooks.set('0', fakeHook);
+
+describe('Embed link test', () => {
+  it.only('Should return a message with embeded message from the URL', async () => {
+    const mockMsg: any = {
+      content:
+        'https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
+      author: {
+        bot: false,
+        avatarURL: () => jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+        id: '123',
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+    expect(webhookSendMock).toHaveBeenCalledTimes(1);
+    expect(msgDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should return if author is a bot', async () => {
+    const mockMsg: any = {
+      content:
+        'https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
+      author: {
+        bot: true,
+        avatarURL: () => jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+        id: '123',
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('Should return if link is not from discord', async () => {
+    const mockMsg: any = {
+      content: 'https://google.com',
+      author: {
+        bot: true,
+        avatarURL: () => jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+        id: '123',
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('Should create a webhook if nothing found', async () => {
+    const createHookMock = jest.fn(() => {});
+    const mockMsg: any = {
+      content: `https://google.com.au`,
+      author: { bot: false },
+      channel: {
+        fetchWebhooks: async () => new Collection<string, Webhook>(),
+        createWebhook: createHookMock,
+      },
+      delete: msgDeleteMock,
+    };
+
+    await embedLink(mockMsg);
+    expect(createHookMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/discord-bot/src/commands/embedLink/index.test.ts
+++ b/discord-bot/src/commands/embedLink/index.test.ts
@@ -1,4 +1,5 @@
 import { Collection, Webhook } from 'discord.js';
+import faker from 'faker';
 import embedLink from '.';
 
 const webhookSendMock = jest.fn(() => {});
@@ -12,10 +13,16 @@ const fakeWebhooks = new Collection<string, Webhook>();
 fakeWebhooks.set('0', fakeHook);
 
 describe('Embed link test', () => {
-  it.only('Should return a message with embeded message from the URL', async () => {
+  it('Should return a message with embeded message from the URL', async () => {
+    const mockedChannel: any = { id: 345 };
+    const mockedFetchedMsg: any = {
+      author: faker.lorem.words(5),
+      createdTimestamp: 1235123123,
+      content: faker.lorem.words(25),
+      id: 678,
+    };
     const mockMsg: any = {
-      content:
-        'https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
+      content: 'https://discord.com/channels/836907335263060028/345/678',
       author: {
         bot: false,
         avatarURL: () => jest.fn(() => {}),
@@ -23,7 +30,16 @@ describe('Embed link test', () => {
       channel: {
         fetchWebhooks: async () => fakeWebhooks,
         createWebhook: async () => fakeHook,
-        id: '123',
+        messages: {
+          fetch: async () => mockedFetchedMsg,
+        },
+      },
+      guild: {
+        channels: {
+          cache: {
+            find: () => mockedChannel,
+          },
+        },
       },
       delete: msgDeleteMock,
     };

--- a/discord-bot/src/commands/embedLink/index.test.ts
+++ b/discord-bot/src/commands/embedLink/index.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Webhook } from 'discord.js';
+import { Collection, GuildChannel, Webhook } from 'discord.js';
 import faker from 'faker';
 import embedLink from '.';
 import { fetchMessageObjectById } from '../../utils/messageFetcher';
@@ -30,11 +30,13 @@ describe('Embed link test', () => {
     };
     mockedMessageFetch.mockReturnValue(mockedFetchedMsg);
     const mockedChannel: any = {
-      id: 345,
+      id: '345',
       messages: {
         fetch: mockedMessageFetch,
       },
     };
+    const guildChannels = new Collection<string, GuildChannel>();
+    guildChannels.set('345', mockedChannel);
     const mockMsg: any = {
       content: 'https://discord.com/channels/836907335263060028/345/678',
       author: {
@@ -47,9 +49,7 @@ describe('Embed link test', () => {
       },
       guild: {
         channels: {
-          cache: {
-            find: () => mockedChannel,
-          },
+          cache: guildChannels,
         },
       },
       delete: msgDeleteMock,
@@ -109,6 +109,7 @@ describe('Embed link test', () => {
         createWebhook: createHookMock,
       },
       delete: msgDeleteMock,
+      guild: {},
     };
 
     await embedLink(mockMsg);

--- a/discord-bot/src/commands/embedLink/index.test.ts
+++ b/discord-bot/src/commands/embedLink/index.test.ts
@@ -99,7 +99,7 @@ describe('Embed link test', () => {
     expect(msgDeleteMock).not.toHaveBeenCalled();
   });
 
-  it('Should create a webhook if nothing found', async () => {
+  it("Should create a webhook if there's none existing in the current channel", async () => {
     const createHookMock = jest.fn(() => {});
     const mockMsg: any = {
       content: `https://google.com.au`,

--- a/discord-bot/src/commands/embedLink/index.ts
+++ b/discord-bot/src/commands/embedLink/index.ts
@@ -20,10 +20,10 @@ const embedLink = async (msg: Message) => {
 
   const firstUrl = hasDiscordUrl[0];
   const idString = firstUrl.replace('https://discord.com/channels/', '');
-
   if (idString.trim().length === 0 || idString.split('/').length < 3) return; // return if link is wrong
 
   const [, channelId, messageId] = idString.split('/');
+
   const sourceChannel = guild?.channels.cache.find(
     ({ id }) => id === channelId
   );
@@ -33,6 +33,7 @@ const embedLink = async (msg: Message) => {
     sourceChannel as TextChannel,
     messageId
   );
+  console.log(`original message ${typeof originalMessage}`);
   if (typeof originalMessage === 'string') return; // return if original message doesn't exist anymore
   originalMessage = originalMessage as Message;
   const originalAuthor = originalMessage.author;

--- a/discord-bot/src/commands/embedLink/index.ts
+++ b/discord-bot/src/commands/embedLink/index.ts
@@ -1,0 +1,65 @@
+import { Message, TextChannel, MessageEmbed } from 'discord.js';
+import { fetchMessageObjectById } from '../../utils/messageFetcher';
+import { fetchWebhook, createWebhook } from '../../utils/webhookProcessor';
+
+const embedLink = async (msg: Message) => {
+  const { author, content, guild, channel } = msg;
+
+  let webhook = await fetchWebhook(channel);
+  if (!webhook) {
+    webhook = await createWebhook(channel); // create webhook if not found
+  }
+
+  if (!webhook) return; // return if can't find or create webhook
+  if (author.bot) return; // return if bot sends the message
+
+  const hasDiscordUrl = content.match(
+    /https:\/\/discord\.com\/channels\/\d+\/\d+\/\d+/gim
+  );
+  if (!hasDiscordUrl) return; // return if no discord url found
+
+  const firstUrl = hasDiscordUrl[0];
+
+  const idString = firstUrl.replace('https://discord.com/channels/', '');
+
+  if (idString.trim().length === 0 || idString.split('/').length < 3) return; // return if link is wrong
+
+  const [, channelId, messageId] = idString.split('/');
+  const sourceChannel = guild?.channels.cache.find(
+    ({ id }) => id === channelId
+  );
+  if (!sourceChannel) return; // return if source channel doesn't exist anymore
+
+  let originalMessage = await fetchMessageObjectById(
+    sourceChannel as TextChannel,
+    messageId
+  );
+  if (typeof originalMessage === 'string') return; // return if original message doesn't exist anymore
+  originalMessage = originalMessage as Message;
+  const originalAuthor = originalMessage.author;
+  const originalTime = originalMessage.createdTimestamp;
+  const embed = new MessageEmbed()
+    .setColor('#0072a8')
+    .setAuthor(
+      originalAuthor.username,
+      originalAuthor.avatarURL() ?? undefined,
+      firstUrl
+    )
+    .setDescription(originalMessage.content)
+    .addFields({ name: 'Jump', value: `[Go to message](${firstUrl})` })
+    .setTimestamp(originalTime)
+    .setFooter(`#${sourceChannel.name}`);
+
+  try {
+    await webhook.send({
+      embeds: [embed],
+      username: author.username,
+      avatarURL: author.avatarURL() ?? undefined,
+    });
+    await msg.delete();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default embedLink;

--- a/discord-bot/src/commands/embedLink/index.ts
+++ b/discord-bot/src/commands/embedLink/index.ts
@@ -22,6 +22,11 @@ const createEmbeddedMessage = (
 const embedLink = async (msg: Message) => {
   const { author, content, guild, channel } = msg;
 
+  // return if guild is invalid.
+  // Guild is only invalid if we're sending a private DM.
+  // Which this bot shouldn't be able to do anyway.
+  if (!guild) return;
+
   if (author.bot) return; // return if bot sends the message
 
   const currentTextChannel = channel as TextChannel;
@@ -40,9 +45,7 @@ const embedLink = async (msg: Message) => {
   if (idString.trim().length === 0 || idString.split('/').length < 3) return; // return if link is wrong
 
   const [, channelId, messageId] = idString.split('/');
-  const sourceChannel = guild?.channels.cache.find(
-    ({ id }) => id === channelId
-  );
+  const sourceChannel = guild.channels.cache.find(({ id }) => id === channelId);
   if (!sourceChannel) return; // return if source channel doesn't exist anymore
 
   const sourceTextChannel = sourceChannel as TextChannel;

--- a/discord-bot/src/commands/embedLink/index.ts
+++ b/discord-bot/src/commands/embedLink/index.ts
@@ -19,7 +19,6 @@ const embedLink = async (msg: Message) => {
   if (!hasDiscordUrl) return; // return if no discord url found
 
   const firstUrl = hasDiscordUrl[0];
-
   const idString = firstUrl.replace('https://discord.com/channels/', '');
 
   if (idString.trim().length === 0 || idString.split('/').length < 3) return; // return if link is wrong
@@ -49,9 +48,9 @@ const embedLink = async (msg: Message) => {
     .addFields({ name: 'Jump', value: `[Go to message](${firstUrl})` })
     .setTimestamp(originalTime)
     .setFooter(`#${sourceChannel.name}`);
-
+  console.log('Before sending');
   try {
-    await webhook.send({
+    await webhook.send(content.replace(firstUrl, ''), {
       embeds: [embed],
       username: author.username,
       avatarURL: author.avatarURL() ?? undefined,

--- a/discord-bot/src/commands/mockSomeone/index.ts
+++ b/discord-bot/src/commands/mockSomeone/index.ts
@@ -1,5 +1,9 @@
 import { Message, TextChannel } from 'discord.js';
 import { getRandomBoolean } from '../../utils/random';
+import {
+  fetchMessageById,
+  fetchLastMessageBeforeId,
+} from '../../utils/messageFetcher';
 
 const isBlank = (content: string) => content.trim() === '';
 
@@ -17,36 +21,6 @@ const generateMockText = (message: string) =>
       return `${outputText}${spongeCharacter}`;
     }, '');
 
-const handleFetchMessageError = (error: Error) => {
-  console.error('CANNOT FETCH MESSAGES IN CHANNEL', error);
-  return '';
-};
-
-const fetchMessageById = async (channel: TextChannel, id: string) => {
-  try {
-    const message = await channel.messages.fetch(id);
-    if (!message) {
-      throw new Error('Cannot fetch message');
-    }
-    return message.content;
-  } catch (error) {
-    return handleFetchMessageError(error);
-  }
-};
-
-const fetchLastMessageBeforeId = async (channel: TextChannel, id: string) => {
-  try {
-    const lastMessages = await channel.messages.fetch({ limit: 1, before: id });
-    const messageRightBefore = lastMessages.first();
-    if (!messageRightBefore) {
-      throw new Error('Cannot fetch previous messages');
-    }
-    return messageRightBefore.content;
-  } catch (error) {
-    return handleFetchMessageError(error);
-  }
-};
-
 const mockSomeone = async ({
   content,
   channel,
@@ -55,6 +29,7 @@ const mockSomeone = async ({
   author,
 }: Message) => {
   if (author.bot) return; // return if sender is bot
+
   const indexOfMockPrefix = content.trimEnd().indexOf(' ');
 
   let chatContent =

--- a/discord-bot/src/config.ts
+++ b/discord-bot/src/config.ts
@@ -1,12 +1,12 @@
 import { ClientUser } from 'discord.js';
 import { CommandConfig } from './utils/messageProcessor';
-
 import ask8Ball from './commands/8ball';
 import danhSomeone from './commands/danhSomeone';
 import mockSomeone from './commands/mockSomeone';
 import { thankUser, checkReputation } from './commands/thanks';
 import getQuoteOfTheDay from './commands/quoteOfTheDay';
 import animatedEmoji from './commands/animatedEmoji';
+import embedLink from './commands/embedLink';
 
 export const getConfigs = (botUser: ClientUser): CommandConfig => ({
   prefixedCommands: {
@@ -31,5 +31,8 @@ export const getConfigs = (botUser: ClientUser): CommandConfig => ({
   emojiMatchCommand: {
     matcher: ':.+:',
     fn: animatedEmoji,
+  },
+  linkMatchCommand: {
+    fn: embedLink,
   },
 });

--- a/discord-bot/src/config.ts
+++ b/discord-bot/src/config.ts
@@ -6,6 +6,7 @@ import danhSomeone from './commands/danhSomeone';
 import mockSomeone from './commands/mockSomeone';
 import { thankUser, checkReputation } from './commands/thanks';
 import getQuoteOfTheDay from './commands/quoteOfTheDay';
+import animatedEmoji from './commands/animatedEmoji';
 
 export const getConfigs = (botUser: ClientUser): CommandConfig => ({
   prefixedCommands: {
@@ -27,4 +28,8 @@ export const getConfigs = (botUser: ClientUser): CommandConfig => ({
       fn: thankUser,
     },
   ],
+  emojiMatchCommand: {
+    matcher: ':.+:',
+    fn: animatedEmoji,
+  },
 });

--- a/discord-bot/src/utils/messageFetcher.ts
+++ b/discord-bot/src/utils/messageFetcher.ts
@@ -1,26 +1,17 @@
 import { Message, TextChannel } from 'discord.js';
 
-const handleFetchMessageError = (error: Error) => {
+const handleFetchMessageError = (
+  error: Error,
+  returnObject: any = undefined
+) => {
   console.error('CANNOT FETCH MESSAGES IN CHANNEL', error);
-  return '';
-};
-
-export const fetchMessageById = async (channel: TextChannel, id: string) => {
-  try {
-    const message = await channel.messages.fetch(id);
-    if (!message) {
-      throw new Error('Cannot fetch message');
-    }
-    return message.content;
-  } catch (error) {
-    return handleFetchMessageError(error);
-  }
+  return returnObject;
 };
 
 export const fetchMessageObjectById = async (
   channel: TextChannel,
   id: string
-): Promise<Message | string> => {
+): Promise<Message> => {
   try {
     const message = await channel.messages.fetch(id);
     if (!message) {
@@ -29,6 +20,18 @@ export const fetchMessageObjectById = async (
     return message;
   } catch (error) {
     return handleFetchMessageError(error);
+  }
+};
+
+export const fetchMessageById = async (channel: TextChannel, id: string) => {
+  try {
+    const message = await fetchMessageObjectById(channel, id);
+    if (!message) {
+      throw new Error('Cannot fetch message');
+    }
+    return message.content;
+  } catch (error) {
+    return handleFetchMessageError(error, '');
   }
 };
 
@@ -44,6 +47,6 @@ export const fetchLastMessageBeforeId = async (
     }
     return messageRightBefore.content;
   } catch (error) {
-    return handleFetchMessageError(error);
+    return handleFetchMessageError(error, '');
   }
 };

--- a/discord-bot/src/utils/messageFetcher.ts
+++ b/discord-bot/src/utils/messageFetcher.ts
@@ -1,0 +1,49 @@
+import { Message, TextChannel } from 'discord.js';
+
+const handleFetchMessageError = (error: Error) => {
+  console.error('CANNOT FETCH MESSAGES IN CHANNEL', error);
+  return '';
+};
+
+export const fetchMessageById = async (channel: TextChannel, id: string) => {
+  try {
+    const message = await channel.messages.fetch(id);
+    if (!message) {
+      throw new Error('Cannot fetch message');
+    }
+    return message.content;
+  } catch (error) {
+    return handleFetchMessageError(error);
+  }
+};
+
+export const fetchMessageObjectById = async (
+  channel: TextChannel,
+  id: string
+): Promise<Message | string> => {
+  try {
+    const message = await channel.messages.fetch(id);
+    if (!message) {
+      throw new Error('Cannot fetch message');
+    }
+    return message;
+  } catch (error) {
+    return handleFetchMessageError(error);
+  }
+};
+
+export const fetchLastMessageBeforeId = async (
+  channel: TextChannel,
+  id: string
+) => {
+  try {
+    const lastMessages = await channel.messages.fetch({ limit: 1, before: id });
+    const messageRightBefore = lastMessages.first();
+    if (!messageRightBefore) {
+      throw new Error('Cannot fetch previous messages');
+    }
+    return messageRightBefore.content;
+  } catch (error) {
+    return handleFetchMessageError(error);
+  }
+};

--- a/discord-bot/src/utils/messageProcessor.test.ts
+++ b/discord-bot/src/utils/messageProcessor.test.ts
@@ -10,6 +10,7 @@ describe('processMessage', () => {
     const km1 = jest.fn();
     const km2 = jest.fn();
     const km3 = jest.fn();
+    const km4 = jest.fn();
     const noMatch = jest.fn();
 
     const config: CommandConfig = {
@@ -35,6 +36,9 @@ describe('processMessage', () => {
         matcher: ':.+:',
         fn: km3,
       },
+      linkMatchCommand: {
+        fn: km4,
+      },
     };
 
     const message = {
@@ -46,6 +50,105 @@ describe('processMessage', () => {
     expect(km1).toHaveBeenCalled();
     expect(km2).toHaveBeenCalled();
     expect(km3).toHaveBeenCalled();
+    expect(km4).not.toHaveBeenCalled();
+    expect(noMatch).not.toHaveBeenCalled();
+  });
+
+  it('process discord link matches', async () => {
+    const km1 = jest.fn();
+    const km2 = jest.fn();
+    const km3 = jest.fn();
+    const km4 = jest.fn();
+    const noMatch = jest.fn();
+
+    const config: CommandConfig = {
+      keywordMatchCommands: [
+        {
+          matchers: ['litte', 'star'],
+          fn: km1,
+        },
+        {
+          matchers: ['star'],
+          fn: km2,
+        },
+        {
+          matchers: ['nein'],
+          fn: noMatch,
+        },
+      ],
+      prefixedCommands: {
+        prefix: '-',
+        commands: [],
+      },
+      emojiMatchCommand: {
+        matcher: ':.+:',
+        fn: km3,
+      },
+      linkMatchCommand: {
+        fn: km4,
+      },
+    };
+
+    const message = {
+      content:
+        'test https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
+    } as Message;
+
+    await processMessage(message, config);
+
+    expect(km1).not.toHaveBeenCalled();
+    expect(km2).not.toHaveBeenCalled();
+    expect(km3).not.toHaveBeenCalled();
+    expect(km4).toHaveBeenCalled();
+    expect(noMatch).not.toHaveBeenCalled();
+  });
+
+  it('process broken discord link', async () => {
+    const km1 = jest.fn();
+    const km2 = jest.fn();
+    const km3 = jest.fn();
+    const km4 = jest.fn();
+    const noMatch = jest.fn();
+
+    const config: CommandConfig = {
+      keywordMatchCommands: [
+        {
+          matchers: ['litte', 'star'],
+          fn: km1,
+        },
+        {
+          matchers: ['star'],
+          fn: km2,
+        },
+        {
+          matchers: ['nein'],
+          fn: noMatch,
+        },
+      ],
+      prefixedCommands: {
+        prefix: '-',
+        commands: [],
+      },
+      emojiMatchCommand: {
+        matcher: ':.+:',
+        fn: km3,
+      },
+      linkMatchCommand: {
+        fn: km4,
+      },
+    };
+
+    const message = {
+      content:
+        'test https://discord.com/channels/836907335263060028/844572466517245954/',
+    } as Message;
+
+    await processMessage(message, config);
+
+    expect(km1).not.toHaveBeenCalled();
+    expect(km2).not.toHaveBeenCalled();
+    expect(km3).not.toHaveBeenCalled();
+    expect(km4).not.toHaveBeenCalled();
     expect(noMatch).not.toHaveBeenCalled();
   });
 
@@ -54,6 +157,7 @@ describe('processMessage', () => {
       const km1 = jest.fn();
       const km2 = jest.fn();
       const km3 = jest.fn();
+      const km4 = jest.fn();
       const config: CommandConfig = {
         keywordMatchCommands: [],
         prefixedCommands: {
@@ -67,6 +171,9 @@ describe('processMessage', () => {
           matcher: ':.+:',
           fn: km3,
         },
+        linkMatchCommand: {
+          fn: km4,
+        },
       };
 
       const message = {
@@ -78,12 +185,14 @@ describe('processMessage', () => {
       expect(km1).not.toHaveBeenCalled();
       expect(km2).toHaveBeenCalled();
       expect(km3).not.toHaveBeenCalled();
+      expect(km4).not.toHaveBeenCalled();
     });
 
-    it('does not process prefix matches with correct prefix', async () => {
+    it('does not process prefix matches with wrong prefix', async () => {
       const km1 = jest.fn();
       const km2 = jest.fn();
       const km3 = jest.fn();
+      const km4 = jest.fn();
 
       const config: CommandConfig = {
         keywordMatchCommands: [],
@@ -98,6 +207,9 @@ describe('processMessage', () => {
           matcher: ':.+:',
           fn: km3,
         },
+        linkMatchCommand: {
+          fn: km4,
+        },
       };
 
       const message = {
@@ -109,6 +221,7 @@ describe('processMessage', () => {
       expect(km1).not.toHaveBeenCalled();
       expect(km2).not.toHaveBeenCalled();
       expect(km3).not.toHaveBeenCalled();
+      expect(km4).not.toHaveBeenCalled();
     });
   });
 });

--- a/discord-bot/src/utils/messageProcessor.test.ts
+++ b/discord-bot/src/utils/messageProcessor.test.ts
@@ -9,6 +9,7 @@ describe('processMessage', () => {
   it('process keyword matches', async () => {
     const km1 = jest.fn();
     const km2 = jest.fn();
+    const km3 = jest.fn();
     const noMatch = jest.fn();
 
     const config: CommandConfig = {
@@ -30,16 +31,21 @@ describe('processMessage', () => {
         prefix: '-',
         commands: [],
       },
+      emojiMatchCommand: {
+        matcher: ':.+:',
+        fn: km3,
+      },
     };
 
     const message = {
-      content: 'star this thing',
+      content: 'star this thing :sadparrot:',
     } as Message;
 
     await processMessage(message, config);
 
     expect(km1).toHaveBeenCalled();
     expect(km2).toHaveBeenCalled();
+    expect(km3).toHaveBeenCalled();
     expect(noMatch).not.toHaveBeenCalled();
   });
 
@@ -47,7 +53,7 @@ describe('processMessage', () => {
     it('process prefix matches with correct prefix', async () => {
       const km1 = jest.fn();
       const km2 = jest.fn();
-
+      const km3 = jest.fn();
       const config: CommandConfig = {
         keywordMatchCommands: [],
         prefixedCommands: {
@@ -56,6 +62,10 @@ describe('processMessage', () => {
             { matcher: 'km1', fn: km1 },
             { matcher: 'km2', fn: km2 },
           ],
+        },
+        emojiMatchCommand: {
+          matcher: ':.+:',
+          fn: km3,
         },
       };
 
@@ -67,11 +77,13 @@ describe('processMessage', () => {
 
       expect(km1).not.toHaveBeenCalled();
       expect(km2).toHaveBeenCalled();
+      expect(km3).not.toHaveBeenCalled();
     });
 
     it('does not process prefix matches with correct prefix', async () => {
       const km1 = jest.fn();
       const km2 = jest.fn();
+      const km3 = jest.fn();
 
       const config: CommandConfig = {
         keywordMatchCommands: [],
@@ -81,6 +93,10 @@ describe('processMessage', () => {
             { matcher: 'km1', fn: km1 },
             { matcher: 'km2', fn: km2 },
           ],
+        },
+        emojiMatchCommand: {
+          matcher: ':.+:',
+          fn: km3,
         },
       };
 
@@ -92,6 +108,7 @@ describe('processMessage', () => {
 
       expect(km1).not.toHaveBeenCalled();
       expect(km2).not.toHaveBeenCalled();
+      expect(km3).not.toHaveBeenCalled();
     });
   });
 });

--- a/discord-bot/src/utils/messageProcessor.ts
+++ b/discord-bot/src/utils/messageProcessor.ts
@@ -33,7 +33,10 @@ export const processMessage = async (
     config.keywordMatchCommands
   );
   const prefixPromises = processPrefixedMatch(message, config.prefixedCommands);
-  const emojiPromises = processEmojiMatch(message, config.emojiMatchCommand);
+  const emojiPromises =
+    prefixPromises.length > 0
+      ? undefined
+      : processEmojiMatch(message, config.emojiMatchCommand); // if match any prefix commands, don't process emoji
   const promises = [
     ...keywordPromises,
     ...prefixPromises,

--- a/discord-bot/src/utils/webhookProcessor.test.ts
+++ b/discord-bot/src/utils/webhookProcessor.test.ts
@@ -2,7 +2,7 @@ import { Collection, Webhook } from 'discord.js';
 import { fetchWebhook, createWebhook } from './webhookProcessor';
 
 describe('Test webhook processor', () => {
-  it('It should return a valid webhook', async () => {
+  it('should return an existing webhook', async () => {
     const mockedWebhook: any = {
       name: 'VAIT-Hook',
       channelID: 123456,
@@ -20,7 +20,7 @@ describe('Test webhook processor', () => {
     expect(result).toEqual(mockedWebhook);
   });
 
-  it('It should return a new webhook', async () => {
+  it('should create a new webhook', async () => {
     const mockedWebhook: any = {
       name: 'VAIT-Hook',
       channelID: 123456,

--- a/discord-bot/src/utils/webhookProcessor.test.ts
+++ b/discord-bot/src/utils/webhookProcessor.test.ts
@@ -9,7 +9,6 @@ describe('Test webhook processor', () => {
     };
     const webhooks = new Collection<string, Webhook>();
     webhooks.set('0', mockedWebhook);
-    webhooks.find = jest.fn(() => mockedWebhook);
     const mockedFetch = jest.fn(async () => webhooks);
     const mockedChannel: any = {
       id: 123456,

--- a/discord-bot/src/utils/webhookProcessor.test.ts
+++ b/discord-bot/src/utils/webhookProcessor.test.ts
@@ -1,0 +1,39 @@
+import { Collection, Webhook } from 'discord.js';
+import { fetchWebhook, createWebhook } from './webhookProcessor';
+
+describe('Test webhook processor', () => {
+  it('It should return a valid webhook', async () => {
+    const mockedWebhook: any = {
+      name: 'VAIT-Hook',
+      channelID: 123456,
+    };
+    const webhooks = new Collection<string, Webhook>();
+    webhooks.set('0', mockedWebhook);
+    webhooks.find = jest.fn(() => mockedWebhook);
+    const mockedFetch = jest.fn(async () => webhooks);
+    const mockedChannel: any = {
+      id: 123456,
+      fetchWebhooks: mockedFetch,
+    };
+
+    const result = await fetchWebhook(mockedChannel);
+    expect(mockedFetch).toHaveBeenCalled();
+    expect(result).toEqual(mockedWebhook);
+  });
+
+  it('It should return a new webhook', async () => {
+    const mockedWebhook: any = {
+      name: 'VAIT-Hook',
+      channelID: 123456,
+    };
+    const mockCreate = jest.fn(async () => mockedWebhook);
+    const mockedChannel: any = {
+      id: 123456,
+      createWebhook: mockCreate,
+    };
+
+    const result = await createWebhook(mockedChannel);
+    expect(mockCreate).toHaveBeenCalled();
+    expect(result).toEqual(mockedWebhook);
+  });
+});

--- a/discord-bot/src/utils/webhookProcessor.ts
+++ b/discord-bot/src/utils/webhookProcessor.ts
@@ -1,15 +1,14 @@
-import { Channel, TextChannel } from 'discord.js';
+import { TextChannel } from 'discord.js';
 
-export const fetchWebhook = async (channel: Channel) => {
-  const textChannel = channel as TextChannel;
+export const fetchWebhook = async (textChannel: TextChannel) => {
   const webHooks = await textChannel.fetchWebhooks();
   return webHooks.find(
-    ({ name, channelID }) => name === 'VAIT-Hook' && channelID === channel.id
+    ({ name, channelID }) =>
+      name === 'VAIT-Hook' && channelID === textChannel.id
   );
 };
 
-export const createWebhook = async (channel: Channel) => {
-  const textChannel = channel as TextChannel;
+export const createWebhook = async (textChannel: TextChannel) => {
   const webhook = await textChannel.createWebhook('VAIT-Hook');
   return webhook;
 };

--- a/discord-bot/src/utils/webhookProcessor.ts
+++ b/discord-bot/src/utils/webhookProcessor.ts
@@ -1,0 +1,15 @@
+import { Channel, TextChannel } from 'discord.js';
+
+export const fetchWebhook = async (channel: Channel) => {
+  const textChannel = channel as TextChannel;
+  const webHooks = await textChannel.fetchWebhooks();
+  return webHooks.find(
+    ({ name, channelID }) => name === 'VAIT-Hook' && channelID === channel.id
+  );
+};
+
+export const createWebhook = async (channel: Channel) => {
+  const textChannel = channel as TextChannel;
+  const webhook = await textChannel.createWebhook('VAIT-Hook');
+  return webhook;
+};


### PR DESCRIPTION

## Description

1. When a non-Nitro user tries to send an animated emoji (which doesn't work), the bot will re-send the entire message with working animated emoji, then delete the original message.
2. When user copies and pastes the message link from a discord channel, the bot will embed the message nicely and remove the link poster message.

## Related Issue
https://github.com/viet-aus-it/vait-discord-bot/issues/41

## Screenshot

1. ![Capture](https://user-images.githubusercontent.com/4377795/118580831-ea311600-b7d3-11eb-9c16-ff48607610e7.JPG)
2. ![Capture](https://user-images.githubusercontent.com/4377795/118925814-b0ead880-b982-11eb-88b3-4796ca6132f3.JPG)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
