### PR TITLE
Refactor Message Processor Tests

### DIFF
--- a/discord-bot/src/commands/danhSomeone/index.test.ts
+++ b/discord-bot/src/commands/danhSomeone/index.test.ts
@@ -37,16 +37,6 @@ describe('danhSomeone', () => {
     expect(replyMock).toHaveBeenCalledTimes(1);
   });
 
-  it('it should return if no keyword is mentioned', () => {
-    const mockMsg: any = {
-      content: 'danh',
-      reply: replyMock,
-    };
-    const mockBotId = '0';
-    danhSomeone(mockMsg, mockBotId);
-    expect(replyMock).not.toHaveBeenCalled();
-  });
-
   it('it should return if mentioned users is undefined', () => {
     const mockMsg: any = {
       content: '-hit',

--- a/discord-bot/src/utils/messageProcessor.test.ts
+++ b/discord-bot/src/utils/messageProcessor.test.ts
@@ -54,102 +54,125 @@ describe('processMessage', () => {
     expect(noMatch).not.toHaveBeenCalled();
   });
 
-  it('process discord link matches', async () => {
-    const km1 = jest.fn();
-    const km2 = jest.fn();
-    const km3 = jest.fn();
-    const km4 = jest.fn();
-    const noMatch = jest.fn();
+  describe('process embeded links and emojis', () => {
+    it('process discord link matches', async () => {
+      const em = jest.fn();
+      const lm = jest.fn();
 
-    const config: CommandConfig = {
-      keywordMatchCommands: [
-        {
-          matchers: ['litte', 'star'],
+      const config: CommandConfig = {
+        keywordMatchCommands: [],
+        prefixedCommands: {
+          prefix: '-',
+          commands: [],
+        },
+        emojiMatchCommand: {
+          matcher: ':.+:',
+          fn: em,
+        },
+        linkMatchCommand: {
+          fn: lm,
+        },
+      };
+
+      const message = {
+        content:
+          'test https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
+      } as Message;
+
+      await processMessage(message, config);
+
+      expect(em).not.toHaveBeenCalled();
+      expect(lm).toHaveBeenCalled();
+    });
+
+    it('process broken discord link', async () => {
+      const km1 = jest.fn();
+      const km2 = jest.fn();
+
+      const config: CommandConfig = {
+        keywordMatchCommands: [],
+        prefixedCommands: {
+          prefix: '-',
+          commands: [],
+        },
+        emojiMatchCommand: {
+          matcher: ':.+:',
           fn: km1,
         },
-        {
-          matchers: ['star'],
+        linkMatchCommand: {
           fn: km2,
         },
-        {
-          matchers: ['nein'],
-          fn: noMatch,
+      };
+
+      const message = {
+        content:
+          'test https://discord.com/channels/836907335263060028/844572466517245954/',
+      } as Message;
+
+      await processMessage(message, config);
+
+      expect(km1).not.toHaveBeenCalled();
+      expect(km2).not.toHaveBeenCalled();
+    });
+
+    it('process emojis', async () => {
+      const km1 = jest.fn();
+      const km2 = jest.fn();
+
+      const config: CommandConfig = {
+        keywordMatchCommands: [],
+        prefixedCommands: {
+          prefix: '-',
+          commands: [],
         },
-      ],
-      prefixedCommands: {
-        prefix: '-',
-        commands: [],
-      },
-      emojiMatchCommand: {
-        matcher: ':.+:',
-        fn: km3,
-      },
-      linkMatchCommand: {
-        fn: km4,
-      },
-    };
-
-    const message = {
-      content:
-        'test https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
-    } as Message;
-
-    await processMessage(message, config);
-
-    expect(km1).not.toHaveBeenCalled();
-    expect(km2).not.toHaveBeenCalled();
-    expect(km3).not.toHaveBeenCalled();
-    expect(km4).toHaveBeenCalled();
-    expect(noMatch).not.toHaveBeenCalled();
-  });
-
-  it('process broken discord link', async () => {
-    const km1 = jest.fn();
-    const km2 = jest.fn();
-    const km3 = jest.fn();
-    const km4 = jest.fn();
-    const noMatch = jest.fn();
-
-    const config: CommandConfig = {
-      keywordMatchCommands: [
-        {
-          matchers: ['litte', 'star'],
+        emojiMatchCommand: {
+          matcher: ':.+:',
           fn: km1,
         },
-        {
-          matchers: ['star'],
+        linkMatchCommand: {
           fn: km2,
         },
-        {
-          matchers: ['nein'],
-          fn: noMatch,
+      };
+
+      const message = {
+        content: ':sadparrot:',
+      } as Message;
+      await processMessage(message, config);
+
+      expect(km1).toHaveBeenCalled();
+      expect(km2).not.toHaveBeenCalled();
+    });
+
+    it('does not process if there is a prefix command', async () => {
+      const km1 = jest.fn(async () => ({}));
+      const em = jest.fn();
+      const lm = jest.fn();
+
+      const config: CommandConfig = {
+        keywordMatchCommands: [],
+        prefixedCommands: {
+          prefix: '-',
+          commands: [{ matcher: 'km1', fn: km1 }],
         },
-      ],
-      prefixedCommands: {
-        prefix: '-',
-        commands: [],
-      },
-      emojiMatchCommand: {
-        matcher: ':.+:',
-        fn: km3,
-      },
-      linkMatchCommand: {
-        fn: km4,
-      },
-    };
+        emojiMatchCommand: {
+          matcher: ':.+:',
+          fn: em,
+        },
+        linkMatchCommand: {
+          fn: lm,
+        },
+      };
 
-    const message = {
-      content:
-        'test https://discord.com/channels/836907335263060028/844572466517245954/',
-    } as Message;
+      const message = {
+        content:
+          '-km1 https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
+      } as Message;
 
-    await processMessage(message, config);
-
-    expect(km1).not.toHaveBeenCalled();
-    expect(km2).not.toHaveBeenCalled();
-    expect(km3).not.toHaveBeenCalled();
-    expect(km4).not.toHaveBeenCalled();
-    expect(noMatch).not.toHaveBeenCalled();
+      await processMessage(message, config);
+      expect(km1).toHaveBeenCalled();
+      expect(em).not.toHaveBeenCalled();
+      expect(lm).not.toHaveBeenCalled();
+    });
   });
 
   describe('process prefix matches', () => {

--- a/discord-bot/src/utils/messageProcessor.ts
+++ b/discord-bot/src/utils/messageProcessor.ts
@@ -1,88 +1,20 @@
 import { Message } from 'discord.js';
 
-export interface PrefixedCommand {
-  matcher: string;
-  fn: (message: Message) => Promise<any>;
-}
+type CommandPromise = Promise<any> | undefined;
 
-export interface PrefixedCommands {
-  prefix: string;
-  commands: Array<PrefixedCommand>;
-}
+type CommandPromises = Array<CommandPromise>;
 
-export interface KeywordMatchCommand {
+interface KeywordMatchCommand {
   matchers: Array<string>;
   fn: (message: Message) => Promise<any>;
 }
-export interface EmojiMatchCommand {
-  matcher: string;
-  fn: (message: Message) => Promise<any>;
-}
 
-export interface LinkMatchCommand {
-  fn: (message: Message) => Promise<any>;
-}
-export interface CommandConfig {
-  prefixedCommands: PrefixedCommands;
-  keywordMatchCommands: Array<KeywordMatchCommand>;
-  emojiMatchCommand: EmojiMatchCommand;
-  linkMatchCommand: LinkMatchCommand;
-}
-
-export const processMessage = async (
-  message: Message,
-  config: CommandConfig
-) => {
-  const keywordPromises = processKeywordMatch(
-    message,
-    config.keywordMatchCommands
-  );
-  const prefixPromises = processPrefixedMatch(message, config.prefixedCommands);
-  const emojiPromises =
-    prefixPromises.filter((p) => p !== undefined).length > 0
-      ? undefined
-      : processEmojiMatch(message, config.emojiMatchCommand); // if match any prefix commands, don't process emoji
-  const linkPromises =
-    prefixPromises.filter((p) => p !== undefined).length > 0
-      ? undefined
-      : processLinkMatch(message, config.linkMatchCommand); // if match any prefix commands, don't process link
-  const promises = [
-    ...keywordPromises,
-    ...prefixPromises,
-    emojiPromises,
-    linkPromises,
-  ].filter((p) => p !== undefined);
-  await Promise.all(promises).catch(console.error);
-};
-
-const processEmojiMatch = (
-  message: Message,
-  config: EmojiMatchCommand
-): Promise<any> | undefined => {
-  const hasEmoji = message.content.match(config.matcher);
-  if (!hasEmoji) {
-    return;
-  }
-  return config.fn(message);
-};
-
-const processLinkMatch = (
-  message: Message,
-  config: LinkMatchCommand
-): Promise<any> | undefined => {
-  const hasDiscordLink = message.content.match(
-    /https:\/\/discord\.com\/channels\/\d+\/\d+\/\d+/gim
-  );
-  if (!hasDiscordLink) {
-    return;
-  }
-  return config.fn(message);
-};
+type KeywordMatchCommands = Array<KeywordMatchCommand>;
 
 const processKeywordMatch = (
   message: Message,
-  config: Array<KeywordMatchCommand>
-): Array<Promise<any> | undefined> => {
+  config: KeywordMatchCommands
+): CommandPromises => {
   return config.map((conf) => {
     const hasKeyword = conf.matchers.some((keyword) =>
       message.content.toLowerCase().includes(keyword)
@@ -96,10 +28,20 @@ const processKeywordMatch = (
   });
 };
 
+interface PrefixedCommand {
+  matcher: string;
+  fn: (message: Message) => Promise<any>;
+}
+
+interface PrefixedCommands {
+  prefix: string;
+  commands: Array<PrefixedCommand>;
+}
+
 const processPrefixedMatch = (
   message: Message,
   config: PrefixedCommands
-): Array<Promise<any> | undefined> => {
+): CommandPromises => {
   return config.commands.map((conf) => {
     const prefixCommand = `${config.prefix}${conf.matcher}`;
     const hasMatchingPrefix = message.content.startsWith(prefixCommand);
@@ -110,4 +52,82 @@ const processPrefixedMatch = (
 
     return conf.fn(message);
   });
+};
+
+interface EmojiMatchCommand {
+  matcher: string;
+  fn: (message: Message) => Promise<any>;
+}
+
+const processEmojiMatch = (
+  message: Message,
+  config: EmojiMatchCommand
+): CommandPromise => {
+  const hasEmoji = message.content.match(config.matcher);
+  if (!hasEmoji) {
+    return;
+  }
+
+  return config.fn(message);
+};
+
+interface LinkMatchCommand {
+  fn: (message: Message) => Promise<any>;
+}
+
+const processLinkMatch = (
+  message: Message,
+  config: LinkMatchCommand
+): CommandPromise => {
+  const hasDiscordLink = message.content.match(
+    /https:\/\/discord\.com\/channels\/\d+\/\d+\/\d+/gim
+  );
+  if (!hasDiscordLink) {
+    return;
+  }
+
+  return config.fn(message);
+};
+
+const removeUndefinedPromises = (promises: CommandPromises) =>
+  promises.filter((p) => p !== undefined);
+
+export interface CommandConfig {
+  prefixedCommands: PrefixedCommands;
+  keywordMatchCommands: KeywordMatchCommands;
+  emojiMatchCommand: EmojiMatchCommand;
+  linkMatchCommand: LinkMatchCommand;
+}
+
+export const processMessage = async (
+  message: Message,
+  config: CommandConfig
+) => {
+  const keywordPromises = processKeywordMatch(
+    message,
+    config.keywordMatchCommands
+  );
+  const prefixPromises = processPrefixedMatch(message, config.prefixedCommands);
+
+  // If message already has a prefix command, don't process these.
+  const hasPrefixPromises = removeUndefinedPromises(prefixPromises).length > 0;
+  const emojiPromises = hasPrefixPromises
+    ? undefined
+    : processEmojiMatch(message, config.emojiMatchCommand);
+  const linkPromises = hasPrefixPromises
+    ? undefined
+    : processLinkMatch(message, config.linkMatchCommand);
+
+  const promises = removeUndefinedPromises([
+    ...keywordPromises,
+    ...prefixPromises,
+    emojiPromises,
+    linkPromises,
+  ]);
+
+  try {
+    await Promise.all(promises);
+  } catch (error) {
+    console.error('ERROR PROCESSING MESSAGE', error);
+  }
 };

--- a/discord-bot/src/utils/messageProcessor.ts
+++ b/discord-bot/src/utils/messageProcessor.ts
@@ -101,11 +101,10 @@ const processPrefixedMatch = (
   config: PrefixedCommands
 ): Array<Promise<any> | undefined> => {
   return config.commands.map((conf) => {
-    const hasMockPrefix = message.content
-      .toLowerCase()
-      .startsWith(`${config.prefix}${conf.matcher}`);
+    const prefixCommand = `${config.prefix}${conf.matcher}`;
+    const hasMatchingPrefix = message.content.startsWith(prefixCommand);
 
-    if (!hasMockPrefix) {
+    if (!hasMatchingPrefix) {
       return;
     }
 


### PR DESCRIPTION
- Force all commands to match in lowercase only.
  - For example: only `-mock` is valid for the mock command, and `-8ball` for the 8ball command
- Add missing test cases for NQN commands where it will skip if there are already other prefix commands running.
- Wrap the NQN related commands (emoji and embed links) test into a `describe()` block to differentiate from the rest
  of the tests, and also clean up unused configs to run these tests.