### PR TITLE
Fix error in Prod build

### DIFF
--- a/discord-bot/.docker/Dockerfile
+++ b/discord-bot/.docker/Dockerfile
@@ -32,8 +32,8 @@ CMD ["/usr/local/bin/discord-bot-entrypoint.sh", "yarn", "start"]
 #####################
 FROM development as build
 ENV NODE_ENV=production
-RUN yarn install --production --non-interactive
 RUN yarn build && \
+    yarn install --production --non-interactive && \
     yarn cache clean
 
 ####################

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -39,9 +39,7 @@
   "dependencies": {
     "@discordjs/opus": "^0.5.0",
     "@prisma/client": "^2.21.2",
-    "concurrently": "^6.0.2",
     "discord.js": "^12.5.3",
-    "eslint-plugin-prettier": "^3.4.0",
     "node-fetch": "^2.6.1",
     "ramda": "^0.27.1"
   },
@@ -54,6 +52,7 @@
     "@types/ramda": "^0.27.40",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
+    "concurrently": "^6.0.2",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
- Fix error in prod build step of building after installing prod dependencies
  TypeScript is not included as a production dependency, so this will fail
  at the next build step because we were relying on TSC for the build script.
![Screenshot from 2021-05-26 10-14-36](https://user-images.githubusercontent.com/4188758/119584453-e9b80100-be0b-11eb-82af-8447f19894aa.png)

- Move concurrently and eslint prettier into devDependencies
