### PR TITLE
Add more tests in: mocking console during testing, and add missing test cases for web hook modules

### DIFF
--- a/discord-bot/jest.config.ts
+++ b/discord-bot/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config.InitialOptions = {
   clearMocks: true,
   collectCoverage: true,
   modulePaths: ['<rootDir>/src/'],
+  setupFilesAfterEnv: ['jest-mock-console/dist/setupTestFramework.js'],
 };
 
 export default config;

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -61,6 +61,7 @@
     "eslint-watch": "^7.0.0",
     "faker": "^5.1.0",
     "jest": "^26.4.2",
+    "jest-mock-console": "^1.1.0",
     "prettier": "^2.1.2",
     "prisma": "^2.21.2",
     "rimraf": "^3.0.2",

--- a/discord-bot/src/commands/animatedEmoji/index.test.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.test.ts
@@ -23,6 +23,20 @@ const fakeEmojiCache = new Collection<string, GuildEmoji>();
 fakeEmojiCache.set('0', fakeAnimatedEmoji);
 
 describe('animated emoji test', () => {
+  it('Should return if message is not sent in a guild', async () => {
+    const mockMsg: any = {
+      content: `:sadparrot:`,
+      author: { bot: false },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+    };
+
+    await animatedEmoji(mockMsg);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+  });
+
   it('Should return if author is a bot', async () => {
     const mockMsg: any = {
       content: `:sadparrot:`,

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -40,7 +40,7 @@ const animatedEmoji = async (originalMessage: Message) => {
   try {
     await webhook.send(newMessage, {
       username: author.username,
-      avatarURL: author.avatarURL() ?? undefined,
+      avatarURL: author.avatarURL() || undefined,
     });
     await originalMessage.delete();
   } catch (error) {

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -23,10 +23,10 @@ const animatedEmoji = async (originalMessage: Message) => {
   let emojiCount = 0;
   emojis.forEach((emoji) => {
     const emoteName = emoji.replace(/:/gim, '');
-    const emote = guild?.emojis.cache.find(({ name }) => name === emoteName);
+    const emote = guild!.emojis.cache.find(
+      ({ name, animated }) => name === emoteName && animated
+    );
     if (!emote) return; // return if no matching emoji found on server
-    if (!emote.animated) return; // return if emoji is not animated
-    if (emote?.name !== emoteName) return; // return if doesn't match emoji's name
 
     newMessage = newMessage.replace(
       new RegExp(`:${emoji}:`, 'gi'),

--- a/discord-bot/src/commands/animatedEmoji/index.ts
+++ b/discord-bot/src/commands/animatedEmoji/index.ts
@@ -4,6 +4,8 @@ import { fetchOrCreateWebhook } from '../../utils/webhookProcessor';
 const animatedEmoji = async (originalMessage: Message) => {
   const { author, content, guild, channel } = originalMessage;
 
+  if (!guild) return; // return if message is not sent from within a guild
+
   if (author.bot) return; // return if bot sends the message
 
   const nitroRegex = /<a?:.+:\d+>/gim;
@@ -23,7 +25,7 @@ const animatedEmoji = async (originalMessage: Message) => {
   let emojiCount = 0;
   emojis.forEach((emoji) => {
     const emoteName = emoji.replace(/:/gim, '');
-    const emote = guild!.emojis.cache.find(
+    const emote = guild.emojis.cache.find(
       ({ name, animated }) => name === emoteName && animated
     );
     if (!emote) return; // return if no matching emoji found on server

--- a/discord-bot/src/commands/embedLink/index.test.ts
+++ b/discord-bot/src/commands/embedLink/index.test.ts
@@ -24,7 +24,7 @@ describe('Embed link test', () => {
       content:
         'https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
       author: {
-        bot: true,
+        bot: false,
         avatarURL: jest.fn(() => {}),
       },
       channel: {

--- a/discord-bot/src/commands/embedLink/index.test.ts
+++ b/discord-bot/src/commands/embedLink/index.test.ts
@@ -1,4 +1,5 @@
 import { Collection, GuildChannel, Webhook } from 'discord.js';
+import mockConsole from 'jest-mock-console';
 import faker from 'faker';
 import embedLink from '.';
 import { fetchMessageObjectById } from '../../utils/messageFetcher';
@@ -18,55 +19,13 @@ const mockedMessageFetch = fetchMessageObjectById as jest.MockedFunction<
 >;
 
 describe('Embed link test', () => {
-  it('Should return a message with embeded message from the URL', async () => {
-    const mockedFetchedMsg: any = {
-      author: {
-        username: faker.lorem.words(5),
-        avatarURL: () => jest.fn(),
-      },
-      createdTimestamp: 1235123123,
-      content: faker.lorem.words(25),
-      id: 678,
-    };
-    mockedMessageFetch.mockReturnValue(mockedFetchedMsg);
-    const mockedChannel: any = {
-      id: '345',
-      messages: {
-        fetch: mockedMessageFetch,
-      },
-    };
-    const guildChannels = new Collection<string, GuildChannel>();
-    guildChannels.set('345', mockedChannel);
-    const mockMsg: any = {
-      content: 'https://discord.com/channels/836907335263060028/345/678',
-      author: {
-        bot: false,
-        avatarURL: () => jest.fn(),
-      },
-      channel: {
-        fetchWebhooks: async () => fakeWebhooks,
-        createWebhook: async () => fakeHook,
-      },
-      guild: {
-        channels: {
-          cache: guildChannels,
-        },
-      },
-      delete: msgDeleteMock,
-    };
-    await embedLink(mockMsg);
-    expect(mockedMessageFetch).toHaveBeenCalledTimes(1);
-    expect(webhookSendMock).toHaveBeenCalledTimes(1);
-    expect(msgDeleteMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('Should return if author is a bot', async () => {
+  it("Should return if guild isn't found", async () => {
     const mockMsg: any = {
       content:
         'https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
       author: {
         bot: true,
-        avatarURL: () => jest.fn(() => {}),
+        avatarURL: jest.fn(() => {}),
       },
       channel: {
         fetchWebhooks: async () => fakeWebhooks,
@@ -80,12 +39,13 @@ describe('Embed link test', () => {
     expect(msgDeleteMock).not.toHaveBeenCalled();
   });
 
-  it('Should return if link is not from discord', async () => {
+  it('Should return if author is a bot', async () => {
     const mockMsg: any = {
-      content: 'https://google.com',
+      content:
+        'https://discord.com/channels/836907335263060028/844572466517245954/844667107581100073',
       author: {
         bot: true,
-        avatarURL: () => jest.fn(() => {}),
+        avatarURL: jest.fn(() => {}),
       },
       channel: {
         fetchWebhooks: async () => fakeWebhooks,
@@ -93,6 +53,7 @@ describe('Embed link test', () => {
         id: '123',
       },
       delete: msgDeleteMock,
+      guild: {},
     };
     await embedLink(mockMsg);
     expect(webhookSendMock).not.toHaveBeenCalled();
@@ -114,5 +75,227 @@ describe('Embed link test', () => {
 
     await embedLink(mockMsg);
     expect(createHookMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should return if link is not from discord', async () => {
+    const mockMsg: any = {
+      content: 'https://google.com',
+      author: {
+        bot: false,
+        avatarURL: jest.fn(() => {}),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+        id: '123',
+      },
+      delete: msgDeleteMock,
+      guild: {},
+    };
+    await embedLink(mockMsg);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('Should return when the source channel does not exist anymore', async () => {
+    const mockedFetchedMsg: any = {
+      author: {
+        username: faker.lorem.words(5),
+        avatarURL: jest.fn(),
+      },
+      createdTimestamp: 1235123123,
+      content: faker.lorem.words(25),
+      id: 678,
+    };
+    mockedMessageFetch.mockReturnValue(mockedFetchedMsg);
+    const guildChannels = new Collection<string, GuildChannel>();
+    const mockMsg: any = {
+      content: 'https://discord.com/channels/836907335263060028/345/678',
+      author: {
+        bot: false,
+        avatarURL: jest.fn(),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        channels: {
+          cache: guildChannels,
+        },
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+    expect(mockedMessageFetch).not.toHaveBeenCalled();
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('Should return when the original message does not exist anymore', async () => {
+    mockedMessageFetch.mockReturnValueOnce(Promise.resolve(undefined));
+    const mockedChannel: any = {
+      id: '345',
+      messages: {
+        fetch: mockedMessageFetch,
+      },
+    };
+    const guildChannels = new Collection<string, GuildChannel>();
+    guildChannels.set('345', mockedChannel);
+    const mockMsg: any = {
+      content: 'https://discord.com/channels/836907335263060028/345/678',
+      author: {
+        bot: false,
+        avatarURL: jest.fn(),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        channels: {
+          cache: guildChannels,
+        },
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it('Should send a message with embeded message from the URL', async () => {
+    const mockedFetchedMsg: any = {
+      author: {
+        username: faker.lorem.words(5),
+        avatarURL: jest.fn(),
+      },
+      createdTimestamp: 1235123123,
+      content: faker.lorem.words(25),
+      id: 678,
+    };
+    mockedMessageFetch.mockReturnValue(mockedFetchedMsg);
+    const mockedChannel: any = {
+      id: '345',
+      messages: {
+        fetch: mockedMessageFetch,
+      },
+    };
+    const guildChannels = new Collection<string, GuildChannel>();
+    guildChannels.set('345', mockedChannel);
+    const mockMsg: any = {
+      content: 'https://discord.com/channels/836907335263060028/345/678',
+      author: {
+        bot: false,
+        avatarURL: jest.fn(),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        channels: {
+          cache: guildChannels,
+        },
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+    expect(mockedMessageFetch).toHaveBeenCalledTimes(1);
+    expect(webhookSendMock).toHaveBeenCalledTimes(1);
+    expect(msgDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should send a message with embeded message from the URL, even if author avatar is undefined', async () => {
+    const mockedFetchedMsg: any = {
+      author: {
+        username: faker.lorem.words(5),
+        avatarURL: () => undefined,
+      },
+      createdTimestamp: 1235123123,
+      content: faker.lorem.words(25),
+      id: 678,
+    };
+    mockedMessageFetch.mockReturnValue(mockedFetchedMsg);
+    const mockedChannel: any = {
+      id: '345',
+      messages: {
+        fetch: mockedMessageFetch,
+      },
+    };
+    const guildChannels = new Collection<string, GuildChannel>();
+    guildChannels.set('345', mockedChannel);
+    const mockMsg: any = {
+      content: 'https://discord.com/channels/836907335263060028/345/678',
+      author: {
+        bot: false,
+        username: faker.lorem.words(1),
+        avatarURL: () => undefined,
+      },
+      channel: {
+        fetchWebhooks: async () => fakeWebhooks,
+        createWebhook: async () => fakeHook,
+      },
+      guild: {
+        channels: {
+          cache: guildChannels,
+        },
+      },
+      delete: msgDeleteMock,
+    };
+    await embedLink(mockMsg);
+    expect(mockedMessageFetch).toHaveBeenCalledTimes(1);
+    expect(webhookSendMock).toHaveBeenCalledTimes(1);
+    expect(msgDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should handle error with console if message cannot be sent', async () => {
+    const fakeFailHook: any = {
+      ...fakeHook,
+      send: jest.fn(() => Promise.reject(new Error('Synthetic Error'))),
+    };
+    const fakeHooks = new Collection<string, Webhook>();
+    fakeHooks.set('0', fakeFailHook);
+    const mockedFetchedMsg: any = {
+      author: {
+        username: faker.lorem.words(5),
+        avatarURL: jest.fn(),
+      },
+      createdTimestamp: 1235123123,
+      content: faker.lorem.words(25),
+      id: 678,
+    };
+    mockedMessageFetch.mockReturnValue(mockedFetchedMsg);
+    const mockedChannel: any = {
+      id: '345',
+      messages: {
+        fetch: mockedMessageFetch,
+      },
+    };
+    const guildChannels = new Collection<string, GuildChannel>();
+    guildChannels.set('345', mockedChannel);
+    const mockMsg: any = {
+      content: 'https://discord.com/channels/836907335263060028/345/678',
+      author: {
+        bot: false,
+        avatarURL: jest.fn(),
+      },
+      channel: {
+        fetchWebhooks: async () => fakeHooks,
+        createWebhook: async () => fakeFailHook,
+      },
+      guild: {
+        channels: {
+          cache: guildChannels,
+        },
+      },
+      delete: msgDeleteMock,
+    };
+    mockConsole();
+    await embedLink(mockMsg);
+    expect(mockedMessageFetch).toHaveBeenCalledTimes(1);
+    expect(webhookSendMock).not.toHaveBeenCalled();
+    expect(msgDeleteMock).not.toHaveBeenCalled();
   });
 });

--- a/discord-bot/src/commands/embedLink/index.ts
+++ b/discord-bot/src/commands/embedLink/index.ts
@@ -7,12 +7,11 @@ const createEmbeddedMessage = (
   { name: channelName }: TextChannel,
   firstUrl: string
 ) => {
-  const { username, avatarURL } = author;
   const embed = new MessageEmbed({
     color: '#0072a8',
     author: {
-      name: username,
-      iconURL: avatarURL() || '',
+      name: author.username,
+      iconURL: author.avatarURL() || '',
       url: firstUrl,
     },
     description: content,
@@ -44,8 +43,6 @@ const embedLink = async (msg: Message) => {
 
   const [firstUrl] = hasDiscordUrl;
   const idString = firstUrl.replace('https://discord.com/channels/', '');
-  if (idString.trim().length === 0 || idString.split('/').length < 3) return; // return if link is wrong
-
   const [, channelId, messageId] = idString.split('/');
   const sourceChannel = guild.channels.cache.find(({ id }) => id === channelId);
   if (!sourceChannel) return; // return if source channel doesn't exist anymore
@@ -67,7 +64,7 @@ const embedLink = async (msg: Message) => {
     await webhook.send(content.replace(firstUrl, ''), {
       embeds: [embed],
       username: author.username,
-      avatarURL: author.avatarURL() ?? undefined,
+      avatarURL: author.avatarURL() || undefined,
     });
     await msg.delete();
   } catch (error) {

--- a/discord-bot/src/utils/messageFetcher/index.ts
+++ b/discord-bot/src/utils/messageFetcher/index.ts
@@ -1,8 +1,8 @@
-import { Message, TextChannel } from 'discord.js';
+import { TextChannel } from 'discord.js';
 
 const handleFetchMessageError = (
   error: Error,
-  returnObject: any = undefined
+  returnObject: string | undefined = undefined
 ) => {
   console.error('CANNOT FETCH MESSAGES IN CHANNEL', error);
   return returnObject;
@@ -11,7 +11,7 @@ const handleFetchMessageError = (
 export const fetchMessageObjectById = async (
   channel: TextChannel,
   id: string
-): Promise<Message> => {
+) => {
   try {
     const message = await channel.messages.fetch(id);
     if (!message) {
@@ -19,7 +19,7 @@ export const fetchMessageObjectById = async (
     }
     return message;
   } catch (error) {
-    return handleFetchMessageError(error);
+    return handleFetchMessageError(error, undefined) as undefined;
   }
 };
 
@@ -31,7 +31,7 @@ export const fetchMessageById = async (channel: TextChannel, id: string) => {
     }
     return message.content;
   } catch (error) {
-    return handleFetchMessageError(error, '');
+    return handleFetchMessageError(error, '') as string;
   }
 };
 
@@ -47,6 +47,6 @@ export const fetchLastMessageBeforeId = async (
     }
     return messageRightBefore.content;
   } catch (error) {
-    return handleFetchMessageError(error, '');
+    return handleFetchMessageError(error, '') as string;
   }
 };

--- a/discord-bot/yarn.lock
+++ b/discord-bot/yarn.lock
@@ -3077,6 +3077,11 @@ jest-message-util@^26.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-mock-console@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock-console/-/jest-mock-console-1.1.0.tgz#81e283688d3161c5c1f4fd3f61a6dd17122c3e87"
+  integrity sha512-9/6a0nXw+Iqq8U0LPpR5GrzpkGYFasD4TPNItKuNP36fUN6/rqcUtcNvzFiq2AssfR0PtSTIzrIHdKOipUxe3Q==
+
 jest-mock@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"


### PR DESCRIPTION
## Description

This PR will add in a couple of changes:

- Add a `jest-mock-console` package, and add tests that cover the specific console line in all of the modules.
- Refactor embedLink, animatedEmoji and Poll modules and their tests, since they are missing a lot of the logic in their test cases. (Refer to the next section)

## Motivation and Context

This is mainly based on the fact that we're not getting full coverage in our test cases just because of console log lines. During the course of working on this PR, I came in to realize that the problem was much more severe when we are actually missing some test case logic as well, and all of them was not reported by Jest/Istanbul code coverage tool, and only shows up after I started mocking the console module.


## How Has This Been Tested?

This test has been tested (again) by Jest/Istanbul to ensure we have 100% coverage, both locally and via our CI/CD process.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
