### PR TITLE
Modify tsconfig json

### DIFF
--- a/discord-bot/tsconfig.json
+++ b/discord-bot/tsconfig.json
@@ -17,5 +17,5 @@
     "declaration": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build", "src/**/*.test.ts"]
 }

--- a/discord-bot/tsconfig.json
+++ b/discord-bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES5",
-    "lib": ["esnext"],
+    "target": "ES2020",
+    "lib": ["ESNext"],
     "types": ["jest", "node"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Ignore tests file from being compiled
  This created some weird testing behaviour with jest, especially when a
  build folder is already there, as it will run tests cases inside the
  build output as well. This will fix the issue.
- Change build target to ES2020
  This is because Node 14 now fully supports ES2020 out of the box, so
  changing this target to ES2020 will reduce some of the polyfill for
  older versions of Node that runs on ES5
