### PR TITLE
Replace faker with @faker-js/faker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "zod": "^3.11.6"
       },
       "devDependencies": {
+        "@faker-js/faker": "^5.5.3",
         "@jest/types": "^27.4.2",
         "@types/faker": "^5.5.9",
         "@types/jest": "^27.0.3",
@@ -33,7 +34,6 @@
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-watch": "^8.0.0",
-        "faker": "^5.1.0",
         "husky": "^7.0.0",
         "jest": "^27.4.5",
         "jest-mock": "^27.4.2",
@@ -714,6 +714,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.2",
@@ -3708,12 +3714,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
-      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8638,6 +8638,12 @@
         }
       }
     },
+    "@faker-js/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
@@ -10917,12 +10923,6 @@
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
-    },
-    "faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "zod": "^3.11.6"
   },
   "devDependencies": {
+    "@faker-js/faker": "^5.5.3",
     "@jest/types": "^27.4.2",
     "@types/faker": "^5.5.9",
     "@types/jest": "^27.0.3",
@@ -62,7 +63,6 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-watch": "^8.0.0",
-    "faker": "^5.1.0",
     "husky": "^7.0.0",
     "jest": "^27.4.5",
     "jest-mock": "^27.4.2",

--- a/src/commands/8ball/index.test.ts
+++ b/src/commands/8ball/index.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { ask8Ball } from '.';
 
 const replyMock = jest.fn(() => {});

--- a/src/commands/cowsay/index.test.ts
+++ b/src/commands/cowsay/index.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { cowsay, removeBacktick } from '.';
 
 const replyMock = jest.fn(() => {});

--- a/src/commands/embedLink/index.test.ts
+++ b/src/commands/embedLink/index.test.ts
@@ -1,6 +1,6 @@
 import { Collection, GuildChannel, Webhook } from 'discord.js';
 import mockConsole from 'jest-mock-console';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { embedLink } from '.';
 import { fetchMessageObjectById } from '../../utils';
 

--- a/src/commands/insult/index.test.ts
+++ b/src/commands/insult/index.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { randomCreate } from './insultGenerator';
 import { fetchMessageObjectById } from '../../utils';
 import { insult } from '.';

--- a/src/commands/mockSomeone/index.test.ts
+++ b/src/commands/mockSomeone/index.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { mockSomeone } from '.';
 
 const replyMock = jest.fn(() => {});

--- a/src/commands/quoteOfTheDay/fetchQuote.test.ts
+++ b/src/commands/quoteOfTheDay/fetchQuote.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { rest } from 'msw';
 import { server } from '../../mocks/server';
 import { fetchQuote, ZEN_QUOTES_URL } from './fetchQuote';

--- a/src/commands/quoteOfTheDay/index.test.ts
+++ b/src/commands/quoteOfTheDay/index.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { getQuoteOfTheDay } from '.';
 import { fetchQuote } from './fetchQuote';
 

--- a/src/commands/weather/fetchWeather.test.ts
+++ b/src/commands/weather/fetchWeather.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { rest } from 'msw';
 import { server } from '../../mocks/server';
 import { fetchWeather, getWeatherURL } from './fetchWeather';

--- a/src/commands/weather/index.test.ts
+++ b/src/commands/weather/index.test.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { weather } from '.';
 import { fetchWeather } from './fetchWeather';
 

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { server } from './mocks/server';
 
 beforeAll(() => server.listen());

--- a/src/types/faker.d.ts
+++ b/src/types/faker.d.ts
@@ -1,0 +1,5 @@
+declare module '@faker-js/faker' {
+  import faker from 'faker';
+
+  export default faker;
+}


### PR DESCRIPTION
...since Marak decided to nuke the faker package and a community has taken over the development of faker.

What this includes:

- Replaced the faker package with @faker-js/faker
- Update the import so that it goes to the correct places
- Create a types file to link the @types/faker package to the @faker-js/faker package for TS support.
