### PR TITLE
Fix Spacing for `setrep` parameters

### DIFF
--- a/src/commands/8ball/index.ts
+++ b/src/commands/8ball/index.ts
@@ -1,4 +1,5 @@
 import { Message } from 'discord.js';
+import { getRandomIntInclusive } from '../../utils';
 
 const REPLIES = [
   'Yes',
@@ -14,7 +15,7 @@ const REPLIES = [
   'Are you even trying?',
   'Keep it up',
 ] as const;
-const get8BallReply = () => REPLIES[Math.floor(Math.random() * REPLIES.length)];
+const get8BallReply = () => REPLIES[getRandomIntInclusive(0, REPLIES.length)];
 
 export const ask8Ball = async (msg: Message) => {
   const { content, channel, author } = msg;

--- a/src/commands/reputation/setReputation.ts
+++ b/src/commands/reputation/setReputation.ts
@@ -20,9 +20,7 @@ export const setReputation = async (msg: Message) => {
   if (!discordUser) return; // return if user not found
   if (discordUser.bot) return; // return if mention bot
 
-  const splittedMessage = msg.content
-    .split(' ')
-    .filter((word) => word.length > 0);
+  const splittedMessage = msg.content.split(/\s+/);
   if (splittedMessage.length !== 3) {
     return channel.send(
       'Wrong format. The correct format is `setRep @username repNumber`'

--- a/src/commands/reputation/setReputation.ts
+++ b/src/commands/reputation/setReputation.ts
@@ -20,7 +20,9 @@ export const setReputation = async (msg: Message) => {
   if (!discordUser) return; // return if user not found
   if (discordUser.bot) return; // return if mention bot
 
-  const splittedMessage = msg.content.split(' ');
+  const splittedMessage = msg.content
+    .split(' ')
+    .filter((word) => word.length > 0);
   if (splittedMessage.length !== 3) {
     return channel.send(
       'Wrong format. The correct format is `setRep @username repNumber`'


### PR DESCRIPTION
## Description
This will provide an additional step in checking for empty words after splitting by spaces, thus in turn will prevent an error occurs when we have an extra space between the parameters

## Related Issue
This will close #82 

## How Has This Been Tested?
- The test was ran on our Bot Testing Server
- Commands typed: `;;;;setrep @Sam 0` and `;;;;setrep @Sam  0`. Both are behaving the same (setting my own rep back to 0).

## Screenshots (if appropriate):
![Screen Shot 2022-03-13 at 1 13 16 am](https://user-images.githubusercontent.com/4188758/158021347-3638fd01-2852-4ad7-81a3-a0605cc49b39.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
