### PR TITLE
Enable thanking multiple people

### DIFF
--- a/src/commands/reputation/giveReputation.test.ts
+++ b/src/commands/reputation/giveReputation.test.ts
@@ -9,24 +9,35 @@ const mockUpdateRep = jest.mocked(updateRep);
 const replyMock = jest.fn(() => {});
 const sendMock = jest.fn(() => {});
 
+const getMockMsg: any = (mockUsers: Collection<string, User>) => ({
+  content: 'thank',
+  reply: replyMock,
+  mentions: {
+    users: mockUsers,
+  },
+  author: {
+    id: '0',
+    bot: false,
+  },
+  channel: {
+    send: sendMock,
+  },
+});
+
 describe('giveRep', () => {
   it('should do nothing if bot is saying the keywords', async () => {
     const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '2' } as User);
-
-    const mockMsg: any = {
-      content: 'thank',
-      reply: replyMock,
-      mentions: {
-        users: mockUsers,
-      },
+    mockUsers.set('0', { id: '1' } as User);
+    const mockMsg = getMockMsg(mockUsers);
+    const botMsg = {
+      ...mockMsg,
       author: {
-        id: '0',
+        ...mockMsg.author,
         bot: true,
       },
     };
 
-    await giveReputation(mockMsg);
+    await giveReputation(botMsg);
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
     expect(replyMock).not.toHaveBeenCalled();
@@ -34,18 +45,7 @@ describe('giveRep', () => {
 
   it('should do nothing if user mention no one', async () => {
     const mockUsers = new Collection<string, User>();
-
-    const mockMsg: any = {
-      content: 'thank',
-      reply: replyMock,
-      mentions: {
-        users: mockUsers,
-      },
-      author: {
-        id: '5',
-        bot: false,
-      },
-    };
+    const mockMsg = getMockMsg(mockUsers);
 
     await giveReputation(mockMsg);
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
@@ -56,18 +56,7 @@ describe('giveRep', () => {
   it('should do nothing if only bot is mentioned', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '1', bot: true } as User);
-
-    const mockMsg: any = {
-      content: 'thank',
-      reply: replyMock,
-      mentions: {
-        users: mockUsers,
-      },
-      author: {
-        id: '5',
-        bot: false,
-      },
-    };
+    const mockMsg = getMockMsg(mockUsers);
 
     await giveReputation(mockMsg);
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
@@ -75,21 +64,11 @@ describe('giveRep', () => {
     expect(replyMock).not.toHaveBeenCalled();
   });
 
-  it('should send reject message if user mention themselves', async () => {
+  it('should send reject message if user mention themself', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '0' } as User);
+    const mockMsg = getMockMsg(mockUsers);
 
-    const mockMsg: any = {
-      content: 'thank',
-      reply: replyMock,
-      mentions: {
-        users: mockUsers,
-      },
-      channel: { send: sendMock },
-      author: {
-        id: '0',
-      },
-    };
     await giveReputation(mockMsg);
 
     expect(replyMock).toHaveBeenCalled();
@@ -97,21 +76,11 @@ describe('giveRep', () => {
 
   it('should call reply and add rep if user mention another user', async () => {
     const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '0' } as User);
-    mockCreateUpdateUser.mockResolvedValueOnce({ id: '0', reputation: 0 });
-    mockUpdateRep.mockResolvedValueOnce({ id: '0', reputation: 1 });
+    mockUsers.set('0', { id: '1' } as User);
+    mockCreateUpdateUser.mockResolvedValueOnce({ id: '1', reputation: 0 });
+    mockUpdateRep.mockResolvedValueOnce({ id: '1', reputation: 1 });
 
-    const mockMsg: any = {
-      content: 'thank',
-      reply: replyMock,
-      mentions: {
-        users: mockUsers,
-      },
-      channel: { send: sendMock },
-      author: {
-        id: '1',
-      },
-    };
+    const mockMsg = getMockMsg(mockUsers);
     await giveReputation(mockMsg);
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
@@ -132,20 +101,7 @@ describe('giveRep', () => {
     mockUpdateRep
       .mockResolvedValueOnce({ id: '2', reputation: 0 })
       .mockResolvedValueOnce({ id: '3', reputation: 0 });
-
-    const mockMsg: any = {
-      content: 'thank',
-      mentions: {
-        users: mockUsers,
-      },
-      author: {
-        id: '0',
-        bot: false,
-      },
-      channel: {
-        send: sendMock,
-      },
-    };
+    const mockMsg = getMockMsg(mockUsers);
 
     await giveReputation(mockMsg);
 

--- a/src/commands/reputation/giveReputation.test.ts
+++ b/src/commands/reputation/giveReputation.test.ts
@@ -7,6 +7,7 @@ const mockCreateUpdateUser = jest.mocked(getOrCreateUser);
 const mockUpdateRep = jest.mocked(updateRep);
 
 const replyMock = jest.fn(() => {});
+const sendMock = jest.fn(() => {});
 
 describe('giveRep', () => {
   it('should do nothing if bot is saying the keywords', async () => {
@@ -31,39 +32,14 @@ describe('giveRep', () => {
     expect(replyMock).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if mentions more than one user', async () => {
+  it('should do nothing if user mention no one', async () => {
     const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '0' } as User);
-    mockUsers.set('1', { id: '1' } as User);
 
     const mockMsg: any = {
       content: 'thank',
       reply: replyMock,
       mentions: {
         users: mockUsers,
-      },
-      author: {
-        bot: false,
-      },
-    };
-
-    await giveReputation(mockMsg);
-
-    expect(replyMock).not.toHaveBeenCalled();
-  });
-
-  it('should do nothing if user mention no one', async () => {
-    const mockUsers = new Collection<string, User>();
-    mockUsers.set('0', { id: '0' } as User);
-
-    const mockMsg: any = {
-      content: 'thank',
-      reply: replyMock,
-      mentions: {
-        users: {
-          first: () => undefined,
-          size: 1,
-        },
       },
       author: {
         id: '5',
@@ -77,7 +53,7 @@ describe('giveRep', () => {
     expect(replyMock).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if bot is mentioned', async () => {
+  it('should do nothing if only bot is mentioned', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '1', bot: true } as User);
 
@@ -99,7 +75,7 @@ describe('giveRep', () => {
     expect(replyMock).not.toHaveBeenCalled();
   });
 
-  it('should send reject message if user mention himself', async () => {
+  it('should send reject message if user mention themselves', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '0' } as User);
 
@@ -109,18 +85,17 @@ describe('giveRep', () => {
       mentions: {
         users: mockUsers,
       },
+      channel: { send: sendMock },
       author: {
         id: '0',
-        bot: false,
       },
     };
-
     await giveReputation(mockMsg);
 
     expect(replyMock).toHaveBeenCalled();
   });
 
-  it('should call reply', async () => {
+  it('should call reply and add rep if user mention another user', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '0' } as User);
     mockCreateUpdateUser.mockResolvedValueOnce({ id: '0', reputation: 0 });
@@ -132,7 +107,7 @@ describe('giveRep', () => {
       mentions: {
         users: mockUsers,
       },
-      channel: { send: replyMock },
+      channel: { send: sendMock },
       author: {
         id: '1',
       },
@@ -141,6 +116,39 @@ describe('giveRep', () => {
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
     expect(mockUpdateRep).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(replyMock).toHaveBeenCalledTimes(0);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should give rep multiple times if mentions more than one user', async () => {
+    const mockUsers = new Collection<string, User>();
+    mockUsers.set('0', { id: '0', bot: false } as User);
+    mockUsers.set('1', { id: '1', bot: true } as User);
+    mockUsers.set('2', { id: '2', bot: false } as User);
+    mockUsers.set('3', { id: '3', bot: false } as User);
+    mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '2', reputation: 0 })
+      .mockResolvedValueOnce({ id: '3', reputation: 0 });
+    mockUpdateRep
+      .mockResolvedValueOnce({ id: '2', reputation: 0 })
+      .mockResolvedValueOnce({ id: '3', reputation: 0 });
+
+    const mockMsg: any = {
+      content: 'thank',
+      mentions: {
+        users: mockUsers,
+      },
+      author: {
+        id: '0',
+        bot: false,
+      },
+      channel: {
+        send: sendMock,
+      },
+    };
+
+    await giveReputation(mockMsg);
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
This PR will allow our bot to thank multiple people at the same time.

## Description
When a thank or giverep command goes through, the bot will:

- Ignore the message if it was sent from a bot.
- Filter out all bot mentions from the message.
- Check for all mentioned users and map these as promises
  - If rep is being given to the message author: Send a reject message
  - If rep is being given to another user: Give rep to that user.
- After mapping, the promises will run all at once.

## Motivation and Context
Resolves #86 

## Screenshots (if appropriate):
- When both myself and Sam 2 are mentioned
![Screen Shot 2022-03-13 at 10 19 30 am](https://user-images.githubusercontent.com/4188758/158038366-c482105c-c681-4d3a-bb52-738f89e65c44.png)
- When myself, Sam Bot and Sam 2 are mentioned
![Screen Shot 2022-03-13 at 10 30 45 am](https://user-images.githubusercontent.com/4188758/158038616-ad4f92ef-6125-4b8d-9186-2f9864f10171.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
