### PR TITLE
Add the webhook intent into our bot so that it can fetch and create webhooks

### DIFF
--- a/src/clients/discord.ts
+++ b/src/clients/discord.ts
@@ -12,6 +12,7 @@ export const getDiscordClient = (options: ClientOptions): Promise<Client> => {
         Intents.FLAGS.GUILDS,
         Intents.FLAGS.GUILD_MESSAGES,
         Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+        Intents.FLAGS.GUILD_WEBHOOKS,
       ],
     });
     client


### PR DESCRIPTION
This was causing an error with creating a poll, because the webhook
could not be created

## Screenshots (if appropriate):
This is now fixed after adding the permission
![Screen Shot 2022-04-09 at 9 07 59 am](https://user-images.githubusercontent.com/4188758/162544965-82fed0e4-ef40-4554-943a-7e2f6e8ae26c.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
