### PR TITLE
Create reusable workflows and deploys continously

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,30 +1,16 @@
 name: Build and deploy Docker Image
 
 on:
-  push:
-    branches:
-      - staging
-      - production
+  workflow_call:
+    inputs:
+      stage:
+        required: true
+        type: string
 
 jobs:
-  get-deploy-stage:
-    name: Get Deploy Stage
-    runs-on: ubuntu-latest
-    outputs:
-      stage: ${{ steps.extract_deploy_stage.outputs.stage }}
-
-    steps:
-      - name: Extract branch name
-        id: extract_deploy_stage
-        shell: bash
-        run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=stage::${BRANCH_NAME}"
-
   build-discord-bot:
     name: Build Discord Bot Docker Image
     runs-on: ubuntu-latest
-    needs: get-deploy-stage
 
     steps:
       - name: Checkout code
@@ -62,9 +48,9 @@ jobs:
   deploy-to-cloud-server:
     name: Deploy to Cloud Server
     runs-on: ubuntu-latest
-    needs: [get-deploy-stage, build-discord-bot]
+    needs: build-discord-bot
     env:
-      STAGE: ${{ needs.get-deploy-stage.outputs.stage }}
+      STAGE: ${{ inputs.stage }}
 
     steps:
       - name: SSH into Cloud Server and deploy

--- a/.github/workflows/deploy-flow.yml
+++ b/.github/workflows/deploy-flow.yml
@@ -1,0 +1,19 @@
+name: "Deployment Action: Build and push Docker images"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test-and-lint:
+    uses: ./.github/workflows/test-and-lint.yml
+  deploy-staging:
+    needs: test-and-lint
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      stage: staging
+  deploy-prod:
+    needs: build-and-deploy-staging
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      stage: production

--- a/.github/workflows/pull-request-flow.yml
+++ b/.github/workflows/pull-request-flow.yml
@@ -1,0 +1,10 @@
+name: "Pull Request Action: Test & Lint"
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test-and-lint-discord-bot:
+    uses: ./.github/workflows/test-and-lint.yml

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,9 +1,7 @@
 name: Tests and Lints packages
 
 on:
-  pull_request:
-    branches:
-      - master
+  workflow_call:
 
 jobs:
   test-and-lint-discord-bot:


### PR DESCRIPTION
## Description

- This PR will split the current deployment and PR workflow into reusable steps, and therefore can be called and reused
to deploy into multiple stages.
- The `Lint and Test` step is now included in the deploy work flow.
- The `deploy` workflow will now only trigger when we publish a new release, and not having to rely on the `staging` and `production` branch any more.

## Motivation and Context
This will avoid a lot of the manual deployment process needed, and often involves babysitting the deployment process, while this PR will introduce a more "continous" and automated way.

## How Has This Been Tested?

This has been tested by running the GitHub Actions right here within this PR. All the existing tests are all green.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
