### PR TITLE
Tets: Use types from @jest/globals instead of @types/jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^7.3.0",
+    "@jest/globals": "^28.1.3",
     "@jest/types": "^28.1.3",
     "@swc-node/register": "^1.5.1",
     "@swc/core": "^1.2.218",
     "@swc/helpers": "^0.4.3",
     "@swc/jest": "^0.2.22",
-    "@types/jest": "^28.1.6",
     "@types/node": "^18.0.6",
     "@types/node-fetch": "^2.6.2",
     "@types/webpack": "^5.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,13 +3,13 @@ lockfileVersion: 5.4
 specifiers:
   '@discordjs/rest': ^1.0.0
   '@faker-js/faker': ^7.3.0
+  '@jest/globals': ^28.1.3
   '@jest/types': ^28.1.3
   '@prisma/client': 4.1.0
   '@swc-node/register': ^1.5.1
   '@swc/core': ^1.2.218
   '@swc/helpers': ^0.4.3
   '@swc/jest': ^0.2.22
-  '@types/jest': ^28.1.6
   '@types/node': ^18.0.6
   '@types/node-fetch': ^2.6.2
   '@types/webpack': ^5.28.0
@@ -58,12 +58,12 @@ dependencies:
 
 devDependencies:
   '@faker-js/faker': 7.3.0
+  '@jest/globals': 28.1.3
   '@jest/types': 28.1.3
   '@swc-node/register': 1.5.1_typescript@4.7.4
   '@swc/core': 1.2.218
   '@swc/helpers': 0.4.3
   '@swc/jest': 0.2.22_@swc+core@1.2.218
-  '@types/jest': 28.1.6
   '@types/node': 18.0.6
   '@types/node-fetch': 2.6.2
   '@types/webpack': 5.28.0_5eesq2kk67jb4f7s3ogboldupe
@@ -1149,13 +1149,6 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
-    dev: true
-
-  /@types/jest/28.1.6:
-    resolution: {integrity: sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==}
-    dependencies:
-      jest-matcher-utils: 28.1.3
-      pretty-format: 28.1.3
     dev: true
 
   /@types/js-levenshtein/1.1.1:

--- a/src/commands/8ball/index.test.ts
+++ b/src/commands/8ball/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { ask8Ball } from '.';
 

--- a/src/commands/allCap/index.test.ts
+++ b/src/commands/allCap/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { allCapExpandText } from '.';
 

--- a/src/commands/cowsay/index.test.ts
+++ b/src/commands/cowsay/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { cowsay, removeBacktick } from '.';
 

--- a/src/commands/danhSomeone/index.test.ts
+++ b/src/commands/danhSomeone/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, beforeEach, jest } from '@jest/globals';
 import { danhSomeone } from '.';
 
 const replyMock = jest.fn();

--- a/src/commands/disclaimer/index.test.ts
+++ b/src/commands/disclaimer/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { getDisclaimer } from '.';
 
 const replyMock = jest.fn();

--- a/src/commands/insult/index.test.ts
+++ b/src/commands/insult/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, beforeEach, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { randomCreate } from './insultGenerator';
 import { insult } from '.';
@@ -14,7 +15,9 @@ const getMockInteraction = (): any => ({
 });
 
 describe('Insult someone test', () => {
-  beforeEach(() => replyMock.mockClear());
+  beforeEach(() => {
+    replyMock.mockClear();
+  });
 
   it('Should send an insult when the cmd is sent', async () => {
     getStringMock.mockImplementationOnce(() => '');
@@ -45,7 +48,9 @@ describe('Insult someone test', () => {
 });
 
 describe('Insult Library test', () => {
-  beforeEach(() => replyMock.mockClear());
+  beforeEach(() => {
+    replyMock.mockClear();
+  });
 
   it('Should be able to generate a random insult', () => {
     const insultString = randomCreate();

--- a/src/commands/mockSomeone/index.test.ts
+++ b/src/commands/mockSomeone/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, beforeEach, it, expect, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { mockSomeone } from '.';
 

--- a/src/commands/poll/index.test.ts
+++ b/src/commands/poll/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { createPoll, NUMBER_AS_STRING } from '.';
 
 const replyMock = jest.fn();

--- a/src/commands/quoteOfTheDay/fetchQuote.test.ts
+++ b/src/commands/quoteOfTheDay/fetchQuote.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { rest } from 'msw';
 import { server } from '../../mocks/server';

--- a/src/commands/quoteOfTheDay/index.test.ts
+++ b/src/commands/quoteOfTheDay/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { getQuoteOfTheDay } from '.';
 import { fetchQuote } from './fetchQuote';

--- a/src/commands/referral/referralNew.test.ts
+++ b/src/commands/referral/referralNew.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { autocomplete, execute } from './referralNew';
 import { getPrismaClient } from '../../clients';
 import { services } from './services';

--- a/src/commands/referral/referralRandom.test.ts
+++ b/src/commands/referral/referralRandom.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { getPrismaClient } from '../../clients';
 import { autocomplete, execute } from './referralRandom';
 

--- a/src/commands/referral/services.test.ts
+++ b/src/commands/referral/services.test.ts
@@ -1,3 +1,4 @@
+import { it, expect } from '@jest/globals';
 import { searchServices } from './services';
 
 it('should return searched options', () => {

--- a/src/commands/reputation/_helpers.test.ts
+++ b/src/commands/reputation/_helpers.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { getPrismaClient } from '../../clients';
 import { getOrCreateUser, updateRep } from './_helpers';
 

--- a/src/commands/reputation/checkReputation.test.ts
+++ b/src/commands/reputation/checkReputation.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { checkReputation } from './checkReputation';
 import { getOrCreateUser } from './_helpers';
 

--- a/src/commands/reputation/giveReputation.test.ts
+++ b/src/commands/reputation/giveReputation.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { Collection, User } from 'discord.js';
 import { giveRepSlashCommand, thankUserInMessage } from './giveReputation';
 import { getOrCreateUser, updateRep } from './_helpers';

--- a/src/commands/reputation/setReputation.test.ts
+++ b/src/commands/reputation/setReputation.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, beforeAll, jest } from '@jest/globals';
 import { User } from 'discord.js';
 import { setReputation } from './setReputation';
 import { getOrCreateUser, updateRep } from './_helpers';

--- a/src/commands/reputation/takeReputation.test.ts
+++ b/src/commands/reputation/takeReputation.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, beforeAll, jest } from '@jest/globals';
 import { User } from 'discord.js';
 import { takeReputation } from './takeReputation';
 import { getOrCreateUser, updateRep } from './_helpers';

--- a/src/commands/weather/fetchWeather.test.ts
+++ b/src/commands/weather/fetchWeather.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, beforeEach } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { rest } from 'msw';
 import { server } from '../../mocks/server';

--- a/src/commands/weather/index.test.ts
+++ b/src/commands/weather/index.test.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect, jest } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 import { weather } from '.';
 import { fetchWeather } from './fetchWeather';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ESNext"],
-    "types": ["jest", "node"],
+    "types": ["node"],
     "allowJs": true,
     "declaration": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Motivation and Context
Since this is maintained directly by the Jest team (so we don't have to wait for `@types/jest` updates, and making it explicit so it's easier to read and maintain.

## How Has This Been Tested?
Unit tests have been run to verfied all the tests still work.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
