### PR TITLE
Create or Get Author User before Rep update

### DIFF
--- a/src/commands/reputation/giveReputation.test.ts
+++ b/src/commands/reputation/giveReputation.test.ts
@@ -77,13 +77,15 @@ describe('Thank user in a message', () => {
   it('should call reply and add rep if user mention another user', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '1' } as User);
-    mockCreateUpdateUser.mockResolvedValueOnce({ id: '1', reputation: 0 });
+    mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '1', reputation: 0 })
+      .mockResolvedValueOnce({ id: '2', reputation: 0 });
     mockUpdateRep.mockResolvedValueOnce({ id: '1', reputation: 1 });
 
     const mockMsg = getMockMsg(mockUsers);
     await thankUserInMessage(mockMsg);
 
-    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledTimes(0);
     expect(sendMock).toHaveBeenCalledTimes(1);
@@ -96,7 +98,9 @@ describe('Thank user in a message', () => {
     mockUsers.set('2', { id: '2', bot: false } as User);
     mockUsers.set('3', { id: '3', bot: false } as User);
     mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '0', reputation: 0 })
       .mockResolvedValueOnce({ id: '2', reputation: 0 })
+      .mockResolvedValueOnce({ id: '0', reputation: 0 })
       .mockResolvedValueOnce({ id: '3', reputation: 0 });
     mockUpdateRep
       .mockResolvedValueOnce({ id: '2', reputation: 0 })
@@ -133,13 +137,15 @@ describe('Give rep slash command', () => {
 
   it('should call reply and add rep if user mention another user', async () => {
     const mockUser = { id: '1' } as User;
-    mockCreateUpdateUser.mockResolvedValueOnce({ id: '1', reputation: 0 });
+    mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '0', reputation: 0 })
+      .mockResolvedValueOnce({ id: '1', reputation: 0 });
     mockUpdateRep.mockResolvedValueOnce({ id: '1', reputation: 1 });
     const mockInteraction = getMockInteraction(mockUser);
 
     await giveRepSlashCommand(mockInteraction);
 
-    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledTimes(1);
   });

--- a/src/commands/reputation/giveReputation.ts
+++ b/src/commands/reputation/giveReputation.ts
@@ -6,10 +6,11 @@ import {
 import { getOrCreateUser, updateRep } from './_helpers';
 import { Subcommand } from '../command';
 
-const plusRep = async (fromUserId: string, discordUserId: string) => {
-  const user = await getOrCreateUser(discordUserId);
+const plusRep = async (fromUserId: string, toUserId: string) => {
+  const author = await getOrCreateUser(fromUserId);
+  const user = await getOrCreateUser(toUserId);
   return updateRep({
-    fromUserId,
+    fromUserId: author.id,
     toUserId: user.id,
     adjustment: { reputation: { increment: 1 } },
   });

--- a/src/commands/reputation/setReputation.test.ts
+++ b/src/commands/reputation/setReputation.test.ts
@@ -37,7 +37,9 @@ describe('setRep', () => {
 
   it('Should call reply when user mentions another user', async () => {
     const mockUser = { id: '0' } as User;
-    mockCreateUpdateUser.mockResolvedValueOnce({ id: '0', reputation: 1 });
+    mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '1', reputation: 1 })
+      .mockResolvedValueOnce({ id: '0', reputation: 1 });
     mockUpdateRep.mockResolvedValueOnce({ id: '0', reputation: 1234 });
 
     const mockInteraction: any = {
@@ -54,7 +56,7 @@ describe('setRep', () => {
     };
     await setReputation(mockInteraction);
 
-    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledWith(

--- a/src/commands/reputation/setReputation.ts
+++ b/src/commands/reputation/setReputation.ts
@@ -34,10 +34,11 @@ export const setReputation = async (
 
   const repNumber = interaction.options.getInteger('rep', true);
   const author = interaction.member!.user;
+  const authorUser = await getOrCreateUser(author.id);
   const discordUser = interaction.options.getUser('user', true);
   const user = await getOrCreateUser(discordUser.id);
   const updatedUser = await updateRep({
-    fromUserId: author.id,
+    fromUserId: authorUser.id,
     toUserId: user.id,
     adjustment: { reputation: { set: repNumber } },
   });

--- a/src/commands/reputation/takeReputation.test.ts
+++ b/src/commands/reputation/takeReputation.test.ts
@@ -38,7 +38,9 @@ describe('takeRep', () => {
 
   it('should send a message if the user has 0 rep', async () => {
     const mockUser = { id: '0' } as User;
-    mockCreateUpdateUser.mockResolvedValueOnce({ id: '0', reputation: 0 });
+    mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '1', reputation: 0 })
+      .mockResolvedValueOnce({ id: '0', reputation: 0 });
     const mockInteraction: any = {
       reply: replyMock,
       member: {
@@ -53,14 +55,16 @@ describe('takeRep', () => {
 
     await takeReputation(mockInteraction);
 
-    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).not.toHaveBeenCalled();
     expect(replyMock).toHaveBeenCalledWith('<@0> currently has 0 rep');
   });
 
   it('Should call reply when user mentions another user', async () => {
     const mockUser = { id: '0' } as User;
-    mockCreateUpdateUser.mockResolvedValueOnce({ id: '0', reputation: 10 });
+    mockCreateUpdateUser
+      .mockResolvedValueOnce({ id: '1', reputation: 10 })
+      .mockResolvedValueOnce({ id: '0', reputation: 10 });
     mockUpdateRep.mockResolvedValueOnce({ id: '0', reputation: 0 });
     const mockInteraction: any = {
       reply: replyMock,
@@ -76,7 +80,7 @@ describe('takeRep', () => {
 
     await takeReputation(mockInteraction);
 
-    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledTimes(1);
     expect(replyMock).toHaveBeenCalledWith(

--- a/src/commands/reputation/takeReputation.ts
+++ b/src/commands/reputation/takeReputation.ts
@@ -29,6 +29,7 @@ export const takeReputation = async (
   }
 
   const author = interaction.member!.user;
+  const authorUser = await getOrCreateUser(author.id);
   const discordUser = interaction.options.getUser('user', true);
   const user = await getOrCreateUser(discordUser.id);
   if (user.reputation === 0) {
@@ -37,7 +38,7 @@ export const takeReputation = async (
   }
 
   const updatedUser = await updateRep({
-    fromUserId: author.id,
+    fromUserId: authorUser.id,
     toUserId: user.id,
     adjustment: { reputation: { decrement: 1 } },
   });


### PR DESCRIPTION
## Description
The problem covered by this issue mostly was because of the author
user not existing in the Users table in the first place, thus making
it a foreign key constraint violation. This will fix that.

## Motivation and Context
This error prevents a newly joined user to thank or give someone a rep.

## Related Issue
Resolves #115 

## How Has This Been Tested?
Unit test has been updated and ran in the repo to make sure all tests passed.
Also deployed the command to test in our test server with a clean db. See screenshot below.

## Screenshots (if appropriate):
![Screen Shot 2022-07-25 at 11 03 01 pm](https://user-images.githubusercontent.com/4188758/180783737-9370f015-bf76-485b-a382-7bc6874d4584.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
