### PR TITLE
Add GatewayIntent Message content for our bot

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -223,6 +223,13 @@ in development, and was messing up deployments.
 - Re-enabled bundling external dependencies, hard-locking `@discordjs/rest` package to 1.0.0 for now,
   because 1.0.1 breaks bundling
 
+## 2.4.6b
+
+### Fixed
+
+- Fix an error where the bot was missing a MessageContent intent so it cannot read the `thank` keyword.
+  See [#122](https://github.com/viet-aus-it/vait-discord-bot/issues/122) and [#123](https://github.com/viet-aus-it/vait-discord-bot/pull/123)
+
 ## \[Unreleased\]
 
 [//]: # (Template:)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,16 @@ there is a change in command registration (adding a new command, editing
 options of an existing one). Running this too many times in a short period
 of time will cause Discord API to **lock your bot out**.
 
-- **NOTE:** When deploy slash commands, if you got `Error: Cannot deploy commands`, it's normally because of your bot doesn't have permission to do so. You need to authorize your bot with scope: `bot` and `applications.commands` using `https://discord.com/api/oauth2/authorize?client_id=$CLIENT_ID&permissions=0&scope=bot%20applications.commands`
+
+### Troubleshooting:
+
+- When deploy slash commands, if you got `Error: Cannot deploy commands`,
+it's normally because of your bot doesn't have permission to do so. You
+need to authorize your bot with scope: `bot` and `applications.commands`
+using `https://discord.com/api/oauth2/authorize?client_id=$CLIENT_ID&permissions=0&scope=bot%20applications.commands`
+
+- If a bot cannot read the messages content, check the [Discord Developer Portal => Bot Section](https://discord.com/developers/applications)
+and see under `Privileged Gateway Intents => Message Content Intent` feature is enabled. This should be enabled.
 
 ### Running lints and tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viet-aus-it/discord-bot",
-  "version": "2.4.6",
+  "version": "2.4.6b",
   "description": "Chat bot for VAIT Discord Server",
   "main": "build/index.js",
   "engines": {

--- a/src/clients/discord.ts
+++ b/src/clients/discord.ts
@@ -14,6 +14,7 @@ export const getDiscordClient = (options: ClientOptions): Promise<Client> => {
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.GuildWebhooks,
+        GatewayIntentBits.MessageContent,
       ],
       partials: [Partials.Channel, Partials.Message, Partials.Reaction],
     });


### PR DESCRIPTION
## Description

This was an update to the recent Discord API v10, that it needs to have the Message content intent to be able to read the messages' content.

In addition to the code, this toggle switch should be turned on in the Discord Developer Portal.
![Screen Shot 2022-08-01 at 12 59 14 pm](https://user-images.githubusercontent.com/4188758/182063873-5118c4ac-bedb-46ae-b859-3412dc3d1e7c.png)


## Motivation and Context
Resolves #122 

## How Has This Been Tested?
- Passing all current unit test
- Deployed a test bot into our test server and testing the keywords there. (Screenshot of testing with @jkiller295)
![Screen Shot 2022-08-01 at 12 57 11 pm](https://user-images.githubusercontent.com/4188758/182063932-2af34df0-555a-407c-a3a9-eefb7d832763.png)
![Screen Shot 2022-08-01 at 12 57 05 pm](https://user-images.githubusercontent.com/4188758/182063926-a9ee21b8-f73b-4245-8c69-323c5baabd6a.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
