### PR TITLE
Feature: Pin message

### DIFF
--- a/src/commands/allCap/index.ts
+++ b/src/commands/allCap/index.ts
@@ -46,19 +46,20 @@ export const allCapExpandText = async (
   }
 
   // If /allcap is detected but content is blank, fetch the latest message in channel
-  content = await fetchLastMessageBeforeId(
+  const fetchedMessage = await fetchLastMessageBeforeId(
     interaction.channel as TextChannel,
     interaction.id
   );
 
   // If it's still blank at this point, then exit
-  if (!content) {
+  if (!fetchedMessage || isBlank(fetchedMessage.content)) {
     await interaction.reply(
       'Cannot fetch latest message. Please try again later.'
     );
     return;
   }
 
+  content = fetchedMessage.content;
   await sendAllCapText(content, interaction);
 };
 

--- a/src/commands/cowsay/index.ts
+++ b/src/commands/cowsay/index.ts
@@ -80,19 +80,20 @@ export const cowsay = async (interaction: ChatInputCommandInteraction) => {
   }
 
   // If /cowsay is detected but content is blank, fetch the latest message in channel
-  content = await fetchLastMessageBeforeId(
+  const fetchedMessage = await fetchLastMessageBeforeId(
     interaction.channel as TextChannel,
     interaction.id
   );
 
   // If it's still blank at this point, then exit
-  if (!content) {
+  if (!fetchedMessage || isBlank(fetchedMessage.content)) {
     await interaction.reply(
       'Cannot fetch latest message. Please try again later.'
     );
     return;
   }
 
+  content = fetchedMessage.content;
   await sendCowsay(content, interaction);
 };
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,6 +5,7 @@ import cowsayCommand from './cowsay';
 import danhCommand from './danhSomeone';
 import insultCommand from './insult';
 import mockCommand from './mockSomeone';
+import pinMessageCommand from './pin';
 import poll from './poll';
 import quoteOfTheDay from './quoteOfTheDay';
 import reputation from './reputation';
@@ -21,6 +22,7 @@ export const commandList: Command[] = [
   danhCommand,
   insultCommand,
   mockCommand,
+  pinMessageCommand,
   poll,
   playPowerball,
   quoteOfTheDay,

--- a/src/commands/mockSomeone/index.ts
+++ b/src/commands/mockSomeone/index.ts
@@ -31,31 +31,43 @@ const generateMockText = (message: string) =>
       return `${outputText}${spongeCharacter}`;
     }, '');
 
+const sendMockText = async (
+  content: string,
+  interaction: ChatInputCommandInteraction
+) => {
+  const reply = generateMockText(content);
+
+  try {
+    await interaction.reply(reply);
+  } catch (error) {
+    console.error('CANNOT SEND MESSAGE', error);
+  }
+};
+
 export const mockSomeone = async (interaction: ChatInputCommandInteraction) => {
   let sentence = interaction.options.getString('sentence');
 
   if (sentence && !isBlank(sentence)) {
-    const mockText = generateMockText(sentence);
-    await interaction.reply(mockText);
+    await sendMockText(sentence, interaction);
     return;
   }
 
   // If /mock is detected but content is blank, fetch the latest message in channel
-  sentence = await fetchLastMessageBeforeId(
+  const fetchedMessage = await fetchLastMessageBeforeId(
     interaction.channel as TextChannel,
     interaction.id
   );
 
   // If it's still blank at this point, then exit
-  if (!sentence || isBlank(sentence)) {
+  if (!fetchedMessage || isBlank(fetchedMessage.content)) {
     await interaction.reply(
       'Cannot fetch latest message. Please try again later.'
     );
     return;
   }
 
-  const mockText = generateMockText(sentence);
-  await interaction.reply(mockText);
+  sentence = fetchedMessage.content;
+  await sendMockText(sentence, interaction);
 };
 
 const command: Command = {

--- a/src/commands/pin/index.test.ts
+++ b/src/commands/pin/index.test.ts
@@ -1,0 +1,213 @@
+import { vi, it, describe, expect, beforeEach } from 'vitest';
+import { faker } from '@faker-js/faker';
+import { Message } from 'discord.js';
+import { MessageType } from 'discord-api-types/v10';
+import { pinMessage } from '.';
+
+const replyMock = vi.fn();
+
+const getMockInteraction = ({
+  getString,
+  fetchCallback,
+}: {
+  getString?: Function;
+  fetchCallback?: Function;
+}): any => ({
+  reply: replyMock,
+  options: {
+    getString,
+  },
+  channel: {
+    messages: { fetch: fetchCallback },
+  },
+});
+
+describe('pinMessage test', () => {
+  beforeEach(() => {
+    replyMock.mockClear();
+  });
+
+  describe('If given the message ID', () => {
+    it('Should reply with error if it cannot fetch the message', async () => {
+      const getString = vi.fn(() => faker.lorem.word(10));
+      const fetchCallback = vi.fn(async () => {
+        throw new Error('Synthetic Error: Cannot fetch message');
+      });
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith(
+        'Cannot retrieve message to pin. Please try again.'
+      );
+    });
+
+    it('Should reply with error if the message is a system message', async () => {
+      const pinMock = vi.fn(async () => {});
+      const message = {
+        content: faker.lorem.words(25),
+        pin: pinMock,
+        type: MessageType.ChannelPinnedMessage,
+      } as unknown as Message;
+      const getString = vi.fn(() => faker.lorem.word(10));
+      const fetchCallback = vi.fn(async () => message);
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(pinMock).toHaveBeenCalledTimes(0);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith(
+        'Cannot pin a system message. Skipping...'
+      );
+    });
+
+    it('Should reply with error if message is already pinned', async () => {
+      const pinned = true;
+      const pinMock = vi.fn(async () => {});
+      const message = {
+        content: faker.lorem.words(25),
+        pinned,
+        pin: pinMock,
+        type: MessageType.ChatInputCommand,
+      } as unknown as Message;
+      const getString = vi.fn(() => faker.lorem.word(10));
+      const fetchCallback = vi.fn(async () => message);
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(pinMock).toHaveBeenCalledTimes(0);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith(
+        'Message is already pinned. Skipping...'
+      );
+    });
+
+    it('Should pin the message given by the ID', async () => {
+      let pinned = false;
+      const pinMock = vi.fn(async () => {
+        pinned = !pinned;
+      });
+      const message = {
+        content: faker.lorem.words(25),
+        pinned,
+        pin: pinMock,
+        type: MessageType.ChatInputCommand,
+      } as unknown as Message;
+      const getString = vi.fn(() => faker.lorem.word(10));
+      const fetchCallback = vi.fn(async () => message);
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(pinMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith('Message is now pinned!');
+    });
+  });
+
+  describe('If not given the message ID', () => {
+    it('Should reply with error if it cannot fetch the message before the pin command', async () => {
+      const getString = vi.fn(() => null);
+      const fetchCallback = vi.fn(async () => {
+        throw new Error('Cannot fetch message');
+      });
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith(
+        'Cannot retrieve message to pin. Please try again.'
+      );
+    });
+
+    it('Should reply with error if the message is a system message', async () => {
+      const pinMock = vi.fn(async () => {});
+      const message = {
+        content: faker.lorem.words(25),
+        pin: pinMock,
+        type: MessageType.ChannelPinnedMessage,
+      } as unknown as Message;
+      const getString = vi.fn(() => faker.lorem.word(10));
+      const fetchCallback = vi.fn(async () => ({
+        first: () => message,
+      }));
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(pinMock).toHaveBeenCalledTimes(0);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith(
+        'Cannot pin a system message. Skipping...'
+      );
+    });
+
+    it('Should reply with error if the message is already pinned', async () => {
+      const pinned = true;
+      const pinMock = vi.fn(async () => {});
+      const message = {
+        content: faker.lorem.words(25),
+        pinned,
+        pin: pinMock,
+        type: MessageType.ChatInputCommand,
+      } as unknown as Message;
+      const getString = vi.fn(() => null);
+      const fetchCallback = vi.fn(async () => ({
+        first: () => message,
+      }));
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(pinMock).toHaveBeenCalledTimes(0);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith(
+        'Message is already pinned. Skipping...'
+      );
+    });
+
+    it('Should pin the message right before the pin command was called if no ID was given', async () => {
+      let pinned = false;
+      const pinMock = vi.fn(async () => {
+        pinned = !pinned;
+      });
+      const message = {
+        content: faker.lorem.words(25),
+        pinned,
+        pin: pinMock,
+        type: MessageType.ChatInputCommand,
+      } as unknown as Message;
+      const getString = vi.fn(() => null);
+      const fetchCallback = vi.fn(async () => ({
+        first: () => message,
+      }));
+      const mockInteraction = getMockInteraction({
+        getString,
+        fetchCallback,
+      });
+
+      await pinMessage(mockInteraction);
+      expect(pinMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock).toHaveBeenCalledWith('Message is now pinned!');
+    });
+  });
+});

--- a/src/commands/pin/index.ts
+++ b/src/commands/pin/index.ts
@@ -1,0 +1,73 @@
+import {
+  ChatInputCommandInteraction,
+  Message,
+  SlashCommandBuilder,
+  TextChannel,
+} from 'discord.js';
+import { MessageType } from 'discord-api-types/v10';
+import { fetchLastMessageBeforeId, fetchMessageById } from '../../utils';
+import { Command } from '../command.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('pin')
+  .setDescription(
+    'Pin a message with an id. If not provided, pin the previous message.'
+  )
+  .addStringOption((option) =>
+    option.setName('message_id').setDescription('Message ID')
+  );
+
+const USER_MESSAGES_TYPE = Object.freeze([
+  MessageType.Default,
+  MessageType.ChatInputCommand,
+  MessageType.Reply,
+]);
+
+const processPinMessage = async (
+  interaction: ChatInputCommandInteraction,
+  message?: Message
+) => {
+  if (!message) {
+    await interaction.reply(
+      'Cannot retrieve message to pin. Please try again.'
+    );
+    return;
+  }
+
+  if (!USER_MESSAGES_TYPE.includes(message.type)) {
+    await interaction.reply('Cannot pin a system message. Skipping...');
+    return;
+  }
+
+  if (message.pinned) {
+    await interaction.reply('Message is already pinned. Skipping...');
+    return;
+  }
+
+  await message.pin();
+  await interaction.reply('Message is now pinned!');
+};
+
+export const pinMessage = async (interaction: ChatInputCommandInteraction) => {
+  const messageId = interaction.options.getString('messageId');
+  const textChannel = interaction.channel as TextChannel;
+
+  if (messageId) {
+    const fetchedMessage = await fetchMessageById(textChannel, messageId!);
+    await processPinMessage(interaction, fetchedMessage);
+    return;
+  }
+
+  const fetchedMessage = await fetchLastMessageBeforeId(
+    textChannel,
+    interaction.id
+  );
+  await processPinMessage(interaction, fetchedMessage);
+};
+
+const command: Command = {
+  data,
+  execute: pinMessage,
+};
+
+export default command;

--- a/src/utils/messageFetcher/index.ts
+++ b/src/utils/messageFetcher/index.ts
@@ -10,9 +10,9 @@ export const fetchLastMessageBeforeId = async (
     if (!messageRightBefore) {
       throw new Error('Cannot fetch previous messages');
     }
-    return messageRightBefore.content;
+    return messageRightBefore;
   } catch (error: any) {
     console.error('CANNOT FETCH MESSAGES IN CHANNEL', error);
-    return '';
+    return undefined;
   }
 };

--- a/src/utils/messageFetcher/index.ts
+++ b/src/utils/messageFetcher/index.ts
@@ -16,3 +16,16 @@ export const fetchLastMessageBeforeId = async (
     return undefined;
   }
 };
+
+export const fetchMessageById = async (channel: TextChannel, id: string) => {
+  try {
+    const message = await channel.messages.fetch(id);
+    if (!message) {
+      throw new Error('Cannot fetch message');
+    }
+    return message;
+  } catch (error: any) {
+    console.error('CANNOT FETCH MESSAGE IN CHANNEL', error);
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Description
Add a pin message command. This command can be invoked by anyone, and can pin the previous message prior to the command (behave like the `mock` or `cowsay` function), or pin the message from an ID.

## Motivation and Context
Discord currently doesn't users without the `Manage messages` permission to pin messages. Giving regular members this permission is way too much power, so this will have to do, until Discord let users do this natively.

## Related Issue
Resolves #111 

## How Has This Been Tested?
- Unit tests have been run and updated.
- Tests have been made on the test server.

## Screenshots (if appropriate):
![Screen Shot 2023-03-25 at 11 56 15 pm](https://user-images.githubusercontent.com/4188758/227718516-e2b15dd1-ab1f-458d-b634-79a7e92b683a.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
