### PR TITLE
New feature: Context Menu Command

### DIFF
--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -75,10 +75,9 @@ export const deployGuildCommands = async (
 ) => {
   const { token, clientId, guildId } = config;
 
-  const commands = [
-    ...commandList.map((cmd) => cmd.data.toJSON()),
-    ...contextMenuCommandList.map((cmd) => cmd.data.toJSON()),
-  ];
+  const commands = [...commandList, ...contextMenuCommandList].map((cmd) =>
+    cmd.data.toJSON()
+  );
 
   const request = Routes.applicationGuildCommands(clientId, guildId);
   return registerCommands({ request, token, body: commands });
@@ -91,7 +90,9 @@ export const deployGlobalCommands = async (
 ) => {
   const { token, clientId } = config;
 
-  const commands = commandList.map((cmd) => cmd.data.toJSON());
+  const commands = [...commandList, ...contextMenuCommandList].map((cmd) =>
+    cmd.data.toJSON()
+  );
 
   const request = Routes.applicationCommands(clientId);
   return registerCommands({ request, token, body: commands });

--- a/src/commands/contextMenuCommands/pin/index.test.ts
+++ b/src/commands/contextMenuCommands/pin/index.test.ts
@@ -1,0 +1,47 @@
+import { vi, it, describe, expect } from 'vitest';
+import { pinMessage } from '.';
+
+const replyMock = vi.fn();
+
+describe('pinMessage context menu test', () => {
+  it('Should return if interaction is not message context menu command', async () => {
+    const mockInteraction: any = {
+      isMessageContextMenuCommand: vi.fn(() => false),
+      reply: replyMock,
+    };
+
+    await pinMessage(mockInteraction);
+    expect(replyMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('Should reply skipping if message is already pinned', async () => {
+    const mockInteraction: any = {
+      isMessageContextMenuCommand: vi.fn(() => true),
+      targetMessage: {
+        pinned: true,
+      },
+      reply: replyMock,
+    };
+
+    await pinMessage(mockInteraction);
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(replyMock).toHaveBeenCalledWith(
+      'Message is already pinned. Skipping...'
+    );
+  });
+
+  it('Should pin the message', async () => {
+    const mockInteraction: any = {
+      isMessageContextMenuCommand: vi.fn(() => true),
+      targetMessage: {
+        pinned: false,
+        pin: vi.fn(),
+      },
+      reply: replyMock,
+    };
+
+    await pinMessage(mockInteraction);
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(replyMock).toHaveBeenCalledWith('Message is now pinned!');
+  });
+});

--- a/src/commands/contextMenuCommands/pin/index.ts
+++ b/src/commands/contextMenuCommands/pin/index.ts
@@ -3,7 +3,7 @@ import {
   ContextMenuCommandBuilder,
   ContextMenuCommandInteraction,
 } from 'discord.js';
-import { ContextMenuCommand } from '../../command';
+import { ContextMenuCommand } from '../../command.js';
 
 export const data = new ContextMenuCommandBuilder()
   .setName('Pin')
@@ -13,7 +13,9 @@ export const pinMessage = async (
   interaction: ContextMenuCommandInteraction
 ) => {
   if (!interaction.isMessageContextMenuCommand()) return;
+
   const message = interaction.targetMessage;
+
   if (message.pinned) {
     await interaction.reply('Message is already pinned. Skipping...');
     return;

--- a/src/commands/contextMenuCommands/pin/index.ts
+++ b/src/commands/contextMenuCommands/pin/index.ts
@@ -1,0 +1,30 @@
+import {
+  ApplicationCommandType,
+  ContextMenuCommandBuilder,
+  ContextMenuCommandInteraction,
+} from 'discord.js';
+import { ContextMenuCommand } from '../../command';
+
+export const data = new ContextMenuCommandBuilder()
+  .setName('Pin')
+  .setType(ApplicationCommandType.Message);
+
+export const pinMessage = async (
+  interaction: ContextMenuCommandInteraction
+) => {
+  if (!interaction.isMessageContextMenuCommand()) return;
+  const message = interaction.targetMessage;
+  if (message.pinned) {
+    await interaction.reply('Message is already pinned. Skipping...');
+    return;
+  }
+  await message.pin();
+  await interaction.reply('Message is now pinned!');
+};
+
+const command: ContextMenuCommand = {
+  data,
+  execute: pinMessage,
+};
+
+export default command;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,4 @@
-import { Command } from './command';
+import { Command, ContextMenuCommand } from './command';
 import allCap from './allCap';
 import ask8ball from './8ball';
 import cowsayCommand from './cowsay';
@@ -14,6 +14,7 @@ import getdisclaimer from './disclaimer';
 import referral from './referral';
 import roles from './roles';
 import playPowerball from './powerball';
+import pinMessageContextMenuCommand from './contextMenuCommands/pin';
 
 export const commandList: Command[] = [
   allCap,
@@ -31,6 +32,10 @@ export const commandList: Command[] = [
   getdisclaimer,
   referral,
   roles,
+];
+
+export const contextMenuCommandList: ContextMenuCommand[] = [
+  pinMessageContextMenuCommand,
 ];
 
 export * from './reputation';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { InteractionType } from 'discord-api-types/v10';
 import { processMessage } from './utils';
 import { getDiscordClient } from './clients';
 import { getConfigs } from './config';
-import { commandList } from './commands';
+import { commandList, contextMenuCommandList } from './commands';
 import { deployGlobalCommands } from './commands/command';
 
 const env = dotenv.config();
@@ -20,7 +20,7 @@ const main = async () => {
   if (process.env.NODE_ENV === 'production') {
     // This should only be run once during the bot startup in production.
     // For development usage, please use `pnpm deploy:command`
-    await deployGlobalCommands(commandList, {
+    await deployGlobalCommands(commandList, contextMenuCommandList, {
       token,
       clientId: client.user.id,
     });
@@ -34,9 +34,18 @@ const main = async () => {
   client.on('interactionCreate', async (interaction) => {
     try {
       const isCommand = interaction.isChatInputCommand();
+      const isContextMenuCommand = interaction.isContextMenuCommand();
       if (isCommand) {
         const { commandName } = interaction;
         const command = commandList.find(
+          (cmd) => cmd.data.name === commandName
+        );
+        return await command?.execute(interaction);
+      }
+
+      if (isContextMenuCommand) {
+        const { commandName } = interaction;
+        const command = contextMenuCommandList.find(
           (cmd) => cmd.data.name === commandName
         );
         return await command?.execute(interaction);

--- a/src/scripts/delete-global-commands.ts
+++ b/src/scripts/delete-global-commands.ts
@@ -10,7 +10,7 @@ const deploy = async () => {
   const clientId = process.env.CLIENT_ID ?? '';
 
   try {
-    await deployGlobalCommands([], { token, clientId });
+    await deployGlobalCommands([], [], { token, clientId });
     process.exit();
   } catch (error) {
     console.error('Cannot delete commands', error);

--- a/src/scripts/delete-guild-commands.ts
+++ b/src/scripts/delete-guild-commands.ts
@@ -11,7 +11,7 @@ const deploy = async () => {
   const guildId = process.env.GUILD_ID ?? '';
 
   try {
-    await deployGuildCommands([], { token, clientId, guildId });
+    await deployGuildCommands([], [], { token, clientId, guildId });
     process.exit();
   } catch (error) {
     console.error('Cannot delete commands', error);

--- a/src/scripts/deploy-guild-commands.ts
+++ b/src/scripts/deploy-guild-commands.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import dotenvExpand from 'dotenv-expand';
 import { deployGuildCommands } from '../commands/command';
-import { commandList } from '../commands';
+import { commandList, contextMenuCommandList } from '../commands';
 
 const env = dotenv.config();
 dotenvExpand.expand(env);
@@ -12,7 +12,11 @@ const deploy = async () => {
   const guildId = process.env.GUILD_ID ?? '';
 
   try {
-    await deployGuildCommands(commandList, { token, clientId, guildId });
+    await deployGuildCommands(commandList, contextMenuCommandList, {
+      token,
+      clientId,
+      guildId,
+    });
     process.exit();
   } catch (error) {
     console.error('Cannot deploy commands', error);


### PR DESCRIPTION
## Description
Added a new type of command, Context Menu Command (CMC), for messages.

## Motivation and Context

At the moment, to use the command ` /pin `you have to obtain a message ID, which required Developer Mode to be enabled in Discord. With CMC, you can just right-click any message and ask the bot to pin it.
CMC can be reused in the future for User related commands as well (like ban, mute, kick). This patch of work provides the facility to create these commands in the future.

## How Has This Been Tested?
This has been tested on a personal Discord server. A test case has been written for it as well.
Since it is a new type of command, more tests were done to make sure the old commands still work.
Ran `pnpm format`and `pnpm test` before pushing. All tests passed. 

## Screenshots (if appropriate):
![pin CMC](https://user-images.githubusercontent.com/51892687/229384861-98b29aba-562b-46b9-895a-50c2d9171b0f.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
