### PR TITLE
New Feature: #136 birthday rep

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -289,6 +289,9 @@ in development, and was messing up deployments.
 
 ## \[Unreleased\]
 
+### Added
+- Enable giving rep to the birthday person. See [#136](https://github.com/viet-aus-it/vait-discord-bot/issues/136)
+
 [//]: # (Template:)
 
 [//]: # (Version number)

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,14 @@ export const getConfigs = (): CommandConfig => {
   return {
     keywordMatchCommands: [
       {
-        matchers: ['thank', 'thanks', 'cảm ơn', 'cám ơn'],
+        matchers: [
+          'thank',
+          'thanks',
+          'cảm ơn',
+          'cám ơn',
+          'happy birthday',
+          'chúc mừng sinh nhật',
+        ],
         fn: thankUserInMessage,
       },
     ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export const getConfigs = (): CommandConfig => {
           'cảm ơn',
           'cám ơn',
           'happy birthday',
+          'hpbd',
           'chúc mừng sinh nhật',
         ],
         fn: thankUserInMessage,


### PR DESCRIPTION
## Description
Enables giving rep to the birthday person by wishing them happy birthday!

## Motivation and Context
Automates giving rep to birthday person as birthday gift.

## Related Issue
Resolves half of #136. This PR doesn't enable giving rep to those wishing happy birthday, only to the person receiving the wish.

## How Has This Been Tested?
Tested using my own bot in the channel `#test_command` under VAIT Bot Testing server. This change is just a config change, and the config mechanism already have unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
