### PR TITLE
Rep Leaderboard Subcommand

### DIFF
--- a/src/commands/reputation/_helpers.ts
+++ b/src/commands/reputation/_helpers.ts
@@ -1,6 +1,8 @@
 import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '../../clients';
 
+const MAX_LEADERBOARD = 10;
+
 export const getOrCreateUser = async (userId: string) => {
   const prisma = getPrismaClient();
 
@@ -58,4 +60,21 @@ export const updateRep = async ({
   ]);
 
   return updatedUser;
+};
+
+export const getTop10 = async () => {
+  const prisma = getPrismaClient();
+
+  return prisma.user.findMany({
+    orderBy: [
+      {
+        reputation: 'desc',
+      },
+    ],
+    select: {
+      id: true,
+      reputation: true,
+    },
+    take: MAX_LEADERBOARD,
+  });
 };

--- a/src/commands/reputation/index.ts
+++ b/src/commands/reputation/index.ts
@@ -4,6 +4,7 @@ import checkRep from './checkReputation';
 import giveRep from './giveReputation';
 import takeRep from './takeReputation';
 import setRep from './setReputation';
+import leaderboard from './leaderboard';
 
 const data = new SlashCommandBuilder()
   .setName('rep')
@@ -11,9 +12,10 @@ const data = new SlashCommandBuilder()
   .addSubcommand(checkRep.data)
   .addSubcommand(giveRep.data)
   .addSubcommand(takeRep.data)
-  .addSubcommand(setRep.data);
+  .addSubcommand(setRep.data)
+  .addSubcommand(leaderboard.data);
 
-const subcommands = [checkRep, giveRep, takeRep, setRep];
+const subcommands = [checkRep, giveRep, takeRep, setRep, leaderboard];
 
 const execute = async (interaction: ChatInputCommandInteraction) => {
   const requestedSubcommand = interaction.options.getSubcommand(true);

--- a/src/commands/reputation/leaderboard.test.ts
+++ b/src/commands/reputation/leaderboard.test.ts
@@ -1,0 +1,184 @@
+import { vi, it, describe, expect } from 'vitest';
+import { getLeaderboard } from './leaderboard';
+import { getTop10 } from './_helpers';
+
+vi.mock('./_helpers');
+const mockGetTop10 = vi.mocked(getTop10);
+const replyMock = vi.fn();
+
+describe('leaderboard', () => {
+  it('Should send reply error if it cannot retrieve the top 10', async () => {
+    mockGetTop10.mockResolvedValueOnce([]);
+    const interaction: any = {
+      reply: replyMock,
+      guild: {},
+    };
+
+    await getLeaderboard(interaction);
+
+    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledWith(
+      'No one has rep to be on the leaderboard, yet.'
+    );
+  });
+
+  it('Should create a leaderboard entry with nickname if it can be fetched', async () => {
+    const userid = '1';
+    mockGetTop10.mockResolvedValueOnce([
+      {
+        id: userid,
+        reputation: 0,
+      },
+    ]);
+    const interaction: any = {
+      reply: replyMock,
+      guild: {
+        members: {
+          fetch() {
+            return {
+              get() {
+                return { nickname: 'sam' };
+              },
+            };
+          },
+        },
+      },
+    };
+
+    await getLeaderboard(interaction);
+
+    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledWith(
+      `\`\`\`
+ # username rep
+ 1      sam   0
+\`\`\``
+    );
+  });
+
+  it('Should create a leaderboard entry with displayName if it can be fetched and nickname cannot be fetched', async () => {
+    const userid = '1';
+    mockGetTop10.mockResolvedValueOnce([
+      {
+        id: userid,
+        reputation: 0,
+      },
+    ]);
+    const interaction: any = {
+      reply: replyMock,
+      guild: {
+        members: {
+          fetch() {
+            return {
+              get() {
+                return { nickname: null, displayName: 'sammy' };
+              },
+            };
+          },
+        },
+      },
+    };
+
+    await getLeaderboard(interaction);
+
+    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledWith(
+      `\`\`\`
+ # username rep
+ 1    sammy   0
+\`\`\``
+    );
+  });
+
+  it('Should create a leaderboard entry with userid if it cannot retrieve the member', async () => {
+    const userid = '1';
+    mockGetTop10.mockResolvedValueOnce([
+      {
+        id: userid,
+        reputation: 0,
+      },
+    ]);
+    const interaction: any = {
+      reply: replyMock,
+      guild: {
+        members: {
+          fetch() {
+            return {
+              get() {
+                return undefined;
+              },
+            };
+          },
+        },
+      },
+    };
+
+    await getLeaderboard(interaction);
+
+    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledWith(
+      `\`\`\`
+ # username rep
+ 1        1   0
+\`\`\``
+    );
+  });
+
+  it('Should send reply with leaderboard with more than 1 record in correct order', async () => {
+    mockGetTop10.mockResolvedValueOnce([
+      {
+        id: '3',
+        reputation: 3,
+      },
+      {
+        id: '2',
+        reputation: 2,
+      },
+      {
+        id: '1',
+        reputation: 1,
+      },
+    ]);
+    const interaction: any = {
+      reply: replyMock,
+      guild: {
+        members: {
+          fetch() {
+            return {
+              get(id: string) {
+                switch (id) {
+                  case '1':
+                    return { nickname: 'sam' };
+
+                  case '2':
+                    return { nickname: null, displayName: 'sam2' };
+
+                  case '3':
+                  default:
+                    return undefined;
+                }
+              },
+            };
+          },
+        },
+      },
+    };
+
+    await getLeaderboard(interaction);
+
+    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledOnce();
+    expect(replyMock).toHaveBeenCalledWith(
+      `\`\`\`
+ # username rep
+ 1        3   3
+ 2     sam2   2
+ 3      sam   1
+\`\`\``
+    );
+  });
+});

--- a/src/commands/reputation/leaderboard.ts
+++ b/src/commands/reputation/leaderboard.ts
@@ -1,0 +1,76 @@
+import {
+  ChatInputCommandInteraction,
+  SlashCommandSubcommandBuilder,
+} from 'discord.js';
+import { getTop10 } from './_helpers';
+import { Subcommand } from '../command';
+
+const data = new SlashCommandSubcommandBuilder()
+  .setName('leaderboard')
+  .setDescription('Show rep leaderboard');
+
+export const buildRepLeaderboard = (
+  records: {
+    username: string;
+    reputation: number;
+  }[]
+) => {
+  const repLength = Math.max(
+    ...records.map((record) => String(record.reputation).length),
+    'rep'.length
+  );
+  const usernameLength = Math.max(
+    ...records.map((record) => record.username.length),
+    'nickname'.length
+  );
+  const titleString = `${'#'.padStart(2, ' ')} ${'username'.padStart(
+    usernameLength,
+    ' '
+  )} ${'rep'.padStart(repLength, ' ')}\n`;
+  return records.reduce((accum, { username, reputation }, currentIndex) => {
+    const position = String(currentIndex + 1).padStart(2, ' ');
+    const paddedUsername = username.padStart(usernameLength, ' ');
+    const repString = String(reputation).padStart(repLength, ' ');
+    return `${accum}${position} ${paddedUsername} ${repString}\n`;
+  }, titleString);
+};
+
+export const getLeaderboard = async (
+  interaction: ChatInputCommandInteraction
+) => {
+  const records = await getTop10();
+  if (records.length === 0) {
+    await interaction.reply('No one has rep to be on the leaderboard, yet.');
+    return;
+  }
+
+  const guild = interaction.guild!;
+  const guildMembers = await guild.members.fetch({
+    user: records.map((r) => r.id),
+  });
+  const mergeRecords = records.map((r) => {
+    const member = guildMembers.get(r.id);
+    if (!member) {
+      return {
+        ...r,
+        username: String(r.id),
+      };
+    }
+
+    const { nickname, displayName } = member;
+    return {
+      ...r,
+      username: nickname || displayName,
+    };
+  });
+
+  const body = buildRepLeaderboard(mergeRecords);
+  await interaction.reply(`\`\`\`\n${body}\`\`\``);
+};
+
+const subcommand: Subcommand = {
+  data,
+  execute: getLeaderboard,
+};
+
+export default subcommand;


### PR DESCRIPTION
## Description
Add a `rep leaderboard` subcommand to show the active top 10 leaderboard.

## Motivation and Context
Currently there's no way to track the rep, and it's hard to do so even for admins because we don't always have access to the bot database on hand. Plus doing it that way is pretty bad anyway.

## Related Issue
Resolves #129

## How Has This Been Tested?
- Add unit test and made sure all previous tests and this test passed.
- Ran some E2E testing in the test server. See screenshot below.

## Screenshots (if appropriate):
![Screen Shot 2023-04-12 at 11 32 31 am](https://user-images.githubusercontent.com/4188758/231325411-6273f836-c16a-4536-a74d-94b92868e9a6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
