### PR TITLE
Refactor test mocks with vitest-mock-extended

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -347,6 +347,7 @@ in development, and was messing up deployments.
 - Create a dedicated Docker task for cleaning up expired referral codes.
 - Remove the side effect of cleaning up referral codes when requesting a random code.
 - Introduced `oxide.ts` to handle async workflows with safe results.
+- Refactored manual test mocks with `vitest-mock-extended`.
 
 [//]: # (Template:)
 

--- a/commit-msg
+++ b/commit-msg
@@ -1,6 +1,0 @@
-feat: refactor tests with vitest-mock-extended
-
-- Replace manual any test mocks with Interaction and Message object
-proxy
-- Replace toHaveBeenCalledTimes(1) with toHaveBeenCalledOnce
-- Replace toHaveBeenCalledTimes(0) with not.toHaveBeenCalled

--- a/commit-msg
+++ b/commit-msg
@@ -1,0 +1,6 @@
+feat: refactor tests with vitest-mock-extended
+
+- Replace manual any test mocks with Interaction and Message object
+proxy
+- Replace toHaveBeenCalledTimes(1) with toHaveBeenCalledOnce
+- Replace toHaveBeenCalledTimes(0) with not.toHaveBeenCalled

--- a/src/commands/8ball/index.test.ts
+++ b/src/commands/8ball/index.test.ts
@@ -1,19 +1,22 @@
-import { vi, it, describe, expect } from 'vitest';
+import { it, describe, expect, beforeEach } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { faker } from '@faker-js/faker';
 import { ask8Ball } from '.';
 
-const replyMock = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('ask 8Ball test', () => {
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
+
   it('Should return yes or no randomly for any question', async () => {
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getString: vi.fn(() => faker.lorem.words(25)),
-      },
-    };
+    mockInteraction.options.getString.mockReturnValueOnce(
+      faker.lorem.words(25)
+    );
 
     await ask8Ball(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
   });
 });

--- a/src/commands/autobump-threads/add-thread.test.ts
+++ b/src/commands/autobump-threads/add-thread.test.ts
@@ -3,6 +3,7 @@ import { mockDeep, mockReset } from 'vitest-mock-extended';
 import {
   ChatInputCommandInteraction,
   TextChannel,
+  PublicThreadChannel,
   ChannelType,
 } from 'discord.js';
 import { addAutobumpThread } from './util';
@@ -11,7 +12,6 @@ import { addAutobumpThreadCommand } from './add-thread';
 vi.mock('./util');
 const mockAddAutobumpThread = vi.mocked(addAutobumpThread);
 const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-const channelId = 'channel_1234';
 const threadId = 'thread_1234';
 
 describe('Add autobump thread', () => {
@@ -20,10 +20,9 @@ describe('Add autobump thread', () => {
   });
 
   it('Should reply with error if the given channel is not a thread', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce({
-      id: channelId,
-      type: ChannelType.GuildText,
-    } as unknown as TextChannel);
+    const mockChannel = mockDeep<TextChannel>();
+    mockChannel.id = 'channel_1234';
+    mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
 
     await addAutobumpThreadCommand(mockInteraction);
     expect(mockInteraction.reply).toBeCalledWith(
@@ -33,10 +32,10 @@ describe('Add autobump thread', () => {
   });
 
   it('Should reply with error if it cannot be saved into the database', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce({
-      id: threadId,
-      type: ChannelType.PublicThread,
-    } as unknown as TextChannel);
+    const mockChannel = mockDeep<PublicThreadChannel>();
+    mockChannel.id = threadId;
+    mockChannel.type = ChannelType.PublicThread;
+    mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
     mockAddAutobumpThread.mockRejectedValueOnce(new Error('Synthetic Error'));
 
     await addAutobumpThreadCommand(mockInteraction);
@@ -47,10 +46,10 @@ describe('Add autobump thread', () => {
   });
 
   it('Should reply with success message if it can be saved into the database', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce({
-      id: threadId,
-      type: ChannelType.PublicThread,
-    } as unknown as TextChannel);
+    const mockChannel = mockDeep<PublicThreadChannel>();
+    mockChannel.id = threadId;
+    mockChannel.type = ChannelType.PublicThread;
+    mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
     mockAddAutobumpThread.mockResolvedValueOnce([threadId]);
 
     await addAutobumpThreadCommand(mockInteraction);

--- a/src/commands/autobump-threads/list-thread.test.ts
+++ b/src/commands/autobump-threads/list-thread.test.ts
@@ -19,8 +19,8 @@ describe('List autobump threads', () => {
 
     await listAutobumpThreadsCommand(mockInteraction);
 
-    expect(mockListAutobumpThread).toHaveBeenCalledTimes(1);
-    expect(mockInteraction.reply).toHaveBeenCalledTimes(1);
+    expect(mockListAutobumpThread).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       "ERROR: Cannot get list of threads from the database, maybe the server threads aren't setup yet?"
     );
@@ -31,8 +31,8 @@ describe('List autobump threads', () => {
 
     await listAutobumpThreadsCommand(mockInteraction);
 
-    expect(mockListAutobumpThread).toHaveBeenCalledTimes(1);
-    expect(mockInteraction.reply).toHaveBeenCalledTimes(1);
+    expect(mockListAutobumpThread).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       'No threads have been setup for autobumping in this server'
     );
@@ -43,8 +43,8 @@ describe('List autobump threads', () => {
 
     await listAutobumpThreadsCommand(mockInteraction);
 
-    expect(mockListAutobumpThread).toHaveBeenCalledTimes(1);
-    expect(mockInteraction.reply).toHaveBeenCalledTimes(1);
+    expect(mockListAutobumpThread).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       `Here is the threads to be autobumped in this server:
 - <#${threadId}>

--- a/src/commands/autobump-threads/remove-thread.test.ts
+++ b/src/commands/autobump-threads/remove-thread.test.ts
@@ -1,23 +1,24 @@
 import { vi, it, describe, expect, beforeEach } from 'vitest';
 import { mockDeep, mockReset } from 'vitest-mock-extended';
-import { ChatInputCommandInteraction, TextChannel } from 'discord.js';
+import { ChatInputCommandInteraction, PublicThreadChannel } from 'discord.js';
 import { removeAutobumpThread } from './util';
 import { removeAutobumpThreadCommand } from './remove-thread';
 
 vi.mock('./util');
 const mockRemoveAutobumpThread = vi.mocked(removeAutobumpThread);
 const mockInteraction = mockDeep<ChatInputCommandInteraction>();
+const mockThread = mockDeep<PublicThreadChannel>();
 const threadId = 'thread_1234';
 
 describe('Add autobump thread', () => {
   beforeEach(() => {
     mockReset(mockInteraction);
+    mockReset(mockThread);
+    mockThread.id = threadId;
   });
 
   it('Should reply with error if it cannot be saved into the database', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce({
-      id: threadId,
-    } as unknown as TextChannel);
+    mockInteraction.options.getChannel.mockReturnValueOnce(mockThread);
     mockRemoveAutobumpThread.mockRejectedValueOnce(
       new Error('Synthetic Error')
     );
@@ -30,9 +31,7 @@ describe('Add autobump thread', () => {
   });
 
   it('Should reply with success message if it can be saved into the database', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce({
-      id: threadId,
-    } as unknown as TextChannel);
+    mockInteraction.options.getChannel.mockReturnValueOnce(mockThread);
     mockRemoveAutobumpThread.mockResolvedValueOnce([threadId]);
 
     await removeAutobumpThreadCommand(mockInteraction);

--- a/src/commands/contextMenuCommands/pin/index.test.ts
+++ b/src/commands/contextMenuCommands/pin/index.test.ts
@@ -1,47 +1,42 @@
-import { vi, it, describe, expect } from 'vitest';
+import { it, describe, expect } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+import {
+  ContextMenuCommandInteraction,
+  MessageContextMenuCommandInteraction,
+} from 'discord.js';
 import { pinMessage } from '.';
-
-const replyMock = vi.fn();
 
 describe('pinMessage context menu test', () => {
   it('Should return if interaction is not message context menu command', async () => {
-    const mockInteraction: any = {
-      isMessageContextMenuCommand: vi.fn(() => false),
-      reply: replyMock,
-    };
+    const mockInteraction = mockDeep<ContextMenuCommandInteraction>();
+    mockInteraction.isMessageContextMenuCommand.mockReturnValueOnce(false);
 
-    await pinMessage(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(0);
+    await pinMessage(mockInteraction as ContextMenuCommandInteraction);
+    expect(mockInteraction.reply).not.toHaveBeenCalled();
   });
 
   it('Should reply skipping if message is already pinned', async () => {
-    const mockInteraction: any = {
-      isMessageContextMenuCommand: vi.fn(() => true),
-      targetMessage: {
-        pinned: true,
-      },
-      reply: replyMock,
-    };
+    const mockInteraction = mockDeep<MessageContextMenuCommandInteraction>();
+    mockInteraction.isMessageContextMenuCommand.mockReturnValueOnce(true);
+    mockInteraction.targetMessage.pinned = true;
 
     await pinMessage(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       'Message is already pinned. Skipping...'
     );
   });
 
   it('Should pin the message', async () => {
-    const mockInteraction: any = {
-      isMessageContextMenuCommand: vi.fn(() => true),
-      targetMessage: {
-        pinned: false,
-        pin: vi.fn(),
-      },
-      reply: replyMock,
-    };
+    const mockInteraction = mockDeep<MessageContextMenuCommandInteraction>();
+    mockInteraction.isMessageContextMenuCommand.mockReturnValueOnce(true);
+    mockInteraction.targetMessage.pinned = false;
 
     await pinMessage(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith('Message is now pinned!');
+    expect(mockInteraction.targetMessage.pin).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      'Message is now pinned!'
+    );
   });
 });

--- a/src/commands/contextMenuCommands/pin/index.ts
+++ b/src/commands/contextMenuCommands/pin/index.ts
@@ -3,7 +3,7 @@ import {
   ContextMenuCommandBuilder,
   ContextMenuCommandInteraction,
 } from 'discord.js';
-import { ContextMenuCommand } from '../../builder.js';
+import { ContextMenuCommand } from '../../builder';
 
 export const data = new ContextMenuCommandBuilder()
   .setName('Pin')

--- a/src/commands/danhSomeone/index.test.ts
+++ b/src/commands/danhSomeone/index.test.ts
@@ -1,96 +1,107 @@
 import { vi, it, describe, expect } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction, User } from 'discord.js';
 import { danhSomeone } from '.';
+import { getRandomIntInclusive, getRandomBoolean } from '../../utils';
 
-const replyMock = vi.fn();
-const getUserMock = vi.fn(
-  (param: `target${number}`): { id: string } | undefined => {
-    return {
-      id: param.substring(6),
-    };
-  }
-);
+vi.mock('../../utils');
+const mockRandomInt = vi.mocked(getRandomIntInclusive);
+const mockRandomBoolean = vi.mocked(getRandomBoolean);
+const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
 
 describe('danhSomeone', () => {
   beforeEach(() => {
-    replyMock.mockReset();
-    getUserMock.mockReset();
-  });
-
-  it('should hit all mentioned users with random damages', () => {
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getUser: getUserMock,
-      },
-      client: {
-        user: {
-          id: '1',
-        },
-      },
-      member: {
-        user: {
-          id: '2',
-        },
-      },
-    };
-
-    danhSomeone(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    mockReset(mockInteraction);
+    mockInteraction.client.user.id = '1';
+    mockInteraction.member.user.id = '2';
   });
 
   it('should not allow user to hit bot', () => {
-    getUserMock.mockImplementation((param: `target${number}`) => {
-      if (param === 'target1') return { id: '1' };
+    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+      if (param === 'target1') return { id: '1' } as User;
+
+      return null;
     });
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getUser: getUserMock,
-      },
-      client: {
-        user: {
-          id: '1',
-        },
-      },
-      member: {
-        user: {
-          id: '2',
-        },
-      },
-    };
 
     danhSomeone(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       "<@2>, I'm your father, you can't hit me."
     );
   });
 
   it('should not allow user to hit themself', () => {
-    getUserMock.mockImplementation((param: `target${number}`) => {
-      if (param === 'target1') return { id: '2' };
+    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+      if (param === 'target1') return { id: '2' } as User;
+
+      return null;
     });
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getUser: getUserMock,
-      },
-      client: {
-        user: {
-          id: '1',
-        },
-      },
-      member: {
-        user: {
-          id: '2',
-        },
-      },
-    };
 
     danhSomeone(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       'Stop hitting yourself <@2>, hit someone else.'
+    );
+  });
+
+  it('should allow user to hit someone else', () => {
+    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+      if (param === 'target1') return { id: '3' } as User;
+
+      return null;
+    });
+    mockRandomInt.mockReturnValueOnce(1);
+    mockRandomBoolean.mockReturnValueOnce(false);
+
+    danhSomeone(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith('<@3> takes 1 dmg.');
+  });
+
+  it('should allow user to hit someone else with a crit', () => {
+    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+      if (param === 'target1') return { id: '3' } as User;
+
+      return null;
+    });
+    mockRandomInt.mockReturnValueOnce(1);
+    mockRandomBoolean.mockReturnValueOnce(true);
+
+    danhSomeone(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      '<@3> takes 1 dmg. Critical Hit!'
+    );
+  });
+
+  it('should allow user to hit many people', () => {
+    mockInteraction.options.getUser
+      .mockReturnValueOnce({ id: '3' } as User)
+      .mockReturnValueOnce({ id: '4' } as User)
+      .mockReturnValueOnce({ id: '5' } as User)
+      .mockReturnValueOnce({ id: '6' } as User)
+      .mockReturnValueOnce({ id: '7' } as User)
+      .mockReturnValueOnce({ id: '8' } as User)
+      .mockReturnValueOnce({ id: '9' } as User)
+      .mockReturnValueOnce({ id: '10' } as User)
+      .mockReturnValueOnce({ id: '11' } as User)
+      .mockReturnValueOnce({ id: '12' } as User);
+    mockRandomInt.mockReturnValue(1);
+    mockRandomBoolean.mockReturnValueOnce(false);
+
+    danhSomeone(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      `<@3> takes 1 dmg.
+<@4> takes 1 dmg.
+<@5> takes 1 dmg.
+<@6> takes 1 dmg.
+<@7> takes 1 dmg.
+<@8> takes 1 dmg.
+<@9> takes 1 dmg.
+<@10> takes 1 dmg.
+<@11> takes 1 dmg.
+<@12> takes 1 dmg.`
     );
   });
 });

--- a/src/commands/disclaimer/index.test.ts
+++ b/src/commands/disclaimer/index.test.ts
@@ -1,29 +1,40 @@
-import { vi, it, describe, expect } from 'vitest';
-import { getDisclaimer } from '.';
+import { it, describe, expect, beforeEach } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { DISCLAIMER_VI, DISCLAIMER_EN, getDisclaimer } from '.';
 
-const replyMock = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
+const getEmbed = (content: string) => {
+  return new EmbedBuilder({
+    author: {
+      name: 'VAIT',
+    },
+    description: content,
+  });
+};
 
 describe('get disclaimer test', () => {
-  it('Should return the disclaimer text', async () => {
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getString: vi.fn(() => ''),
-      },
-    };
-
-    await getDisclaimer(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+  beforeEach(() => {
+    mockReset(mockInteraction);
   });
-  it('Should return the EN disclaimer text', async () => {
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getString: vi.fn(() => 'en'),
-      },
-    };
+
+  it('Should return the disclaimer text', async () => {
+    mockInteraction.options.getString.mockReturnValueOnce('');
 
     await getDisclaimer(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith({
+      embeds: [getEmbed(DISCLAIMER_VI)],
+    });
+  });
+
+  it('Should return the EN disclaimer text', async () => {
+    mockInteraction.options.getString.mockReturnValueOnce('en');
+
+    await getDisclaimer(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith({
+      embeds: [getEmbed(DISCLAIMER_EN)],
+    });
   });
 });

--- a/src/commands/disclaimer/index.ts
+++ b/src/commands/disclaimer/index.ts
@@ -22,9 +22,9 @@ const data = new SlashCommandBuilder()
       )
   );
 
-const DISCLAIMER_VI =
+export const DISCLAIMER_VI =
   'Trong trường hợp nhóm này bị điều tra bởi các cơ quan trực thuộc bộ công an (hoặc các tổ chức chính trị tương tự), tôi khẳng định mình không liên quan tới nhóm hoặc những cá nhân khác trong nhóm này. Tôi không rõ tại sao mình lại có mặt ở đây, có lẽ tài khoản của tôi đã được thêm bởi một bên thứ ba. Tôi cũng xin khẳng định rằng mình không hề giúp sức cho những hành động của các thành viên trong nhóm này.' as const;
-const DISCLAIMER_EN =
+export const DISCLAIMER_EN =
   'In case of an investigation by any federal entity or similar, I do not have any involvement with this group or with the people in it. I do not know how I am here, probably added by a third party, and I do not support any actions by the members of this group.' as const;
 
 export const getDisclaimer = async (

--- a/src/commands/insult/index.test.ts
+++ b/src/commands/insult/index.test.ts
@@ -1,44 +1,35 @@
-import { vi, it, describe, expect } from 'vitest';
+import { it, describe, expect, expectTypeOf } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { faker } from '@faker-js/faker';
 import { randomCreate } from './insultGenerator';
 import { insult } from '.';
 
-const replyMock = vi.fn();
-
-const getStringMock = vi.fn();
-
-const getMockInteraction = (): any => ({
-  reply: replyMock,
-  options: {
-    getString: getStringMock,
-  },
-});
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('Insult someone test', () => {
-  beforeEach(() => replyMock.mockClear());
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
 
   it('Should send an insult when the cmd is sent', async () => {
-    getStringMock.mockImplementationOnce(() => '');
-    const mockInteraction = getMockInteraction();
+    mockInteraction.options.getString.mockReturnValueOnce('');
 
     await insult(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
   });
 
   it('Should insult the chat content', async () => {
-    getStringMock.mockImplementationOnce(() => faker.lorem.words(2));
-    const mockInteraction = getMockInteraction();
+    mockInteraction.options.getString.mockReturnValueOnce(faker.lorem.words(2));
 
     await insult(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
   });
 });
 
 describe('Insult Library test', () => {
-  beforeEach(() => replyMock.mockClear());
-
   it('Should be able to generate a random insult', () => {
     const insultString = randomCreate();
-    expect(typeof insultString).toEqual('string');
+    expectTypeOf(insultString).toBeString();
   });
 });

--- a/src/commands/mockSomeone/index.test.ts
+++ b/src/commands/mockSomeone/index.test.ts
@@ -1,71 +1,75 @@
-import { vi, it, describe, expect } from 'vitest';
+import { it, describe, expect } from 'vitest';
+import { mock, mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction, Collection, Message } from 'discord.js';
 import { faker } from '@faker-js/faker';
 import { mockSomeone } from '.';
 
-const replyMock = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
+const mockMessage = mock<Message<true>>();
 
 describe('mockSomeone test', () => {
   beforeEach(() => {
-    replyMock.mockClear();
+    mockReset(mockInteraction);
+    mockReset(mockMessage);
   });
 
   it('Should mock text if it was called by /mock', async () => {
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {
-        getString: vi.fn(() => faker.lorem.words(25)),
-      },
-    };
+    mockInteraction.options.getString.mockReturnValueOnce(
+      faker.lorem.words(25)
+    );
 
     await mockSomeone(mockInteraction);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
   });
 
   describe('For /mock call with blank content', () => {
-    const getMockInteraction = (fetchCallback: Function): any => ({
-      reply: replyMock,
-      options: {
-        getString: vi.fn(() => ''),
-      },
-      channel: {
-        messages: { fetch: fetchCallback },
-      },
-    });
-
     describe('Fetching previous message', () => {
-      it('Should throw error if previous message cannot be retrieved', async () => {
-        const fetchMock = vi.fn(async () => ({
-          first: () => undefined,
-        }));
-        const mockInteraction = getMockInteraction(fetchMock);
-
-        await mockSomeone(mockInteraction);
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+      beforeEach(() => {
+        mockInteraction.options.getString.mockReturnValueOnce('');
       });
 
-      it('Should return blank if previous message is blank', async () => {
-        const blankMessage = { content: '' };
-        const fetchMock = vi.fn(async () => ({
-          first: () => blankMessage,
-        }));
-        const mockInteraction = getMockInteraction(fetchMock);
+      it('Should reply with error if previous message cannot be retrieved', async () => {
+        const mockMessageCollection = new Collection<string, Message<true>>();
+        mockInteraction.options.getString.mockReturnValueOnce('');
+        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(
+          mockMessageCollection
+        );
 
         await mockSomeone(mockInteraction);
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(mockInteraction.reply).toHaveBeenCalledOnce();
+        expect(mockInteraction.reply).toHaveBeenCalledWith(
+          'Cannot fetch latest message. Please try again later.'
+        );
+      });
+
+      it('Should reply with error if previous message is blank', async () => {
+        mockMessage.content = '';
+        const mockMessageCollection = new Collection<string, Message<true>>();
+        mockInteraction.options.getString.mockReturnValueOnce('');
+        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(
+          mockMessageCollection
+        );
+
+        await mockSomeone(mockInteraction);
+        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(mockInteraction.reply).toHaveBeenCalledOnce();
+        expect(mockInteraction.reply).toHaveBeenCalledWith(
+          'Cannot fetch latest message. Please try again later.'
+        );
       });
 
       it('Should mock the previous message', async () => {
-        const messageWithContent = { content: faker.lorem.words(25) };
-        const fetchMock = vi.fn(async () => ({
-          first: () => messageWithContent,
-        }));
-        const mockInteraction = getMockInteraction(fetchMock);
+        mockMessage.content = faker.lorem.words(25);
+        const mockMessageCollection = new Collection<string, Message<true>>();
+        mockInteraction.options.getString.mockReturnValueOnce('');
+        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(
+          mockMessageCollection
+        );
 
         await mockSomeone(mockInteraction);
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(mockInteraction.reply).toHaveBeenCalledOnce();
       });
     });
   });

--- a/src/commands/mockSomeone/index.ts
+++ b/src/commands/mockSomeone/index.ts
@@ -47,14 +47,22 @@ export const mockSomeone = async (interaction: ChatInputCommandInteraction) => {
   );
 
   // If it's still blank at this point, then exit
-  if (fetchedMessage.isErr() || isBlank(fetchedMessage.unwrap().content)) {
+  if (fetchedMessage.isErr()) {
     await interaction.reply(
       'Cannot fetch latest message. Please try again later.'
     );
     return;
   }
 
-  const reply = generateMockText(fetchedMessage.unwrap().content);
+  const { content } = fetchedMessage.unwrap();
+  if (isBlank(content)) {
+    await interaction.reply(
+      'Cannot fetch latest message. Please try again later.'
+    );
+    return;
+  }
+
+  const reply = generateMockText(content);
   await interaction.reply(reply);
 };
 

--- a/src/commands/moderateUsers/index.ts
+++ b/src/commands/moderateUsers/index.ts
@@ -29,12 +29,13 @@ export const removeUserByRole = async (
   }
 
   const channel = interaction.channel as ThreadChannel;
-  if (!channel?.isThread) {
+  if (!channel?.isThread()) {
     await interaction.reply(
       "You can't remove all users with role from entire channel. This command only works in a thread."
     );
     return;
   }
+
   await interaction.deferReply({ ephemeral: true });
   const role = interaction.options.getRole('name', true);
   const members = await channel.members.fetch({ withMember: true });

--- a/src/commands/poll/index.ts
+++ b/src/commands/poll/index.ts
@@ -86,10 +86,11 @@ export const createPoll = async (interaction: ChatInputCommandInteraction) => {
 
   const embed = createEmbeddedMessage(question, pollOptions);
 
-  const pollMsg = (await interaction.reply({
+  const pollMsg = await interaction.reply({
     embeds: [embed],
     fetchReply: true,
-  })) as Message;
+  });
+
   const promises = pollOptions.map((_value, index) =>
     pollMsg.react(REACTION_NUMBERS[index])
   );

--- a/src/commands/powerball/index.ts
+++ b/src/commands/powerball/index.ts
@@ -17,27 +17,41 @@ const data = new SlashCommandBuilder()
       .setMaxValue(10)
   );
 
+const MIN_POWER_BALL_NUMBER = 1;
+const MAX_POWER_BALL_NUMBER = 35;
+const MAX_POWER_HIT_NUMBER = 20;
+
+const padNumber = (num: number) => num.toString(10).padStart(2, '0');
+
 const getMainNumbers = () => {
   return Array(7)
     .fill(0)
-    .reduce((array: number[]) => {
-      const number = getUniqueRandomIntInclusive(array, 1, 35);
-      array.push(number);
-      return array;
-    }, [])
-    .map((number) => `${number.toString().padStart(2, '0')}`)
-    .join(' ');
+    .reduce((accumulator, _value, index) => {
+      const number = getUniqueRandomIntInclusive(
+        accumulator,
+        MIN_POWER_BALL_NUMBER,
+        MAX_POWER_BALL_NUMBER
+      );
+      return `${accumulator}${index > 0 ? ' ' : ''}${padNumber(number)}`;
+    }, '');
 };
 
 const getPowerballNumber = () => {
-  return getRandomIntInclusive(1, 20).toString().padStart(2, '0');
+  const number = getRandomIntInclusive(
+    MIN_POWER_BALL_NUMBER,
+    MAX_POWER_HIT_NUMBER
+  );
+  return padNumber(number);
 };
 
-export const getPowerBallGame = (count: number): string => {
+const getPowerBallGame = (count: number) => {
   const games = Array(count)
     .fill(undefined)
-    .map(() => `${getMainNumbers()} PB:${getPowerballNumber()}`)
-    .join('\n');
+    .reduce<string>((accumulator, _value, index) => {
+      const line = `${getMainNumbers()} PB:${getPowerballNumber()}`;
+      return `${accumulator}${index > 0 ? '\n' : ''}${line}`;
+    }, '');
+
   return `\`\`\`${games}\`\`\``;
 };
 

--- a/src/commands/powerball/powerball.test.ts
+++ b/src/commands/powerball/powerball.test.ts
@@ -1,43 +1,62 @@
-import { getPowerBallGame } from '.';
-import { getUniqueRandomIntInclusive } from '../../utils';
-// /powerball n number (1-10)
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockDeep, mockReset, captor } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { powerball } from '.';
 
-// 1. 7 unique numbers from 1 - 35
-// 2. PB numbers from 1 - 20
-// 3. n number of games
-// 4. format
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('powerball', () => {
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
+
   it('should return correct number of games', async () => {
     const gameCount = 5;
-    const games = getPowerBallGame(gameCount);
-    expect(games.split('\n').length).toEqual(gameCount);
+    mockInteraction.options.getInteger.mockReturnValueOnce(gameCount);
+    const games = captor<string>();
+
+    await powerball(mockInteraction);
+
+    expect(mockInteraction.reply).toHaveBeenCalledWith(games);
+    expect(games.value.split('\n').length).toEqual(gameCount);
   });
 
   it('should return 7 unique numbers from 1-35', async () => {
-    let singleGame = getPowerBallGame(1).replaceAll('`', '');
-    singleGame = singleGame.substring(0, singleGame.indexOf('P')).trim();
-    const uniqueNumbers = singleGame.split(' ');
+    mockInteraction.options.getInteger.mockReturnValueOnce(1);
+    const singleGame = captor<string>();
+
+    await powerball(mockInteraction);
+
+    expect(mockInteraction.reply).toHaveBeenCalledWith(singleGame);
+
+    let gameValue = singleGame.value.replaceAll('`', '');
+    gameValue = gameValue.substring(0, gameValue.indexOf('PB')).trim();
+    const uniqueNumbers = gameValue.split(' ');
     expect(uniqueNumbers.length).toEqual(new Set(uniqueNumbers).size);
   });
 
   it('should return the correct format', async () => {
-    const games = getPowerBallGame(10);
-    expect(games.match(/([0-9]{2}\s){7}\sPB: [0-9]{2}\n?/));
+    mockInteraction.options.getInteger.mockReturnValueOnce(10);
+    const games = captor<string>();
+    const regex = /^(\d{2}\s){7}PB:\d{2}$/gm; // Matches multiline of 00 00 00 00 00 00 00 PB:00
+
+    await powerball(mockInteraction);
+
+    expect(mockInteraction.reply).toHaveBeenCalledWith(games);
+    expect(games.value.replaceAll('`', '')).toMatch(regex);
   });
 
   it('PB numbers from 1 - 20', async () => {
-    const singleGame = getPowerBallGame(1).replaceAll('`', '');
-    const powerball = singleGame
-      .substring(singleGame.indexOf(':') + 1, singleGame.length)
-      .trim();
-    expect(Number(powerball)).lessThanOrEqual(20).greaterThanOrEqual(1);
-  });
-});
+    mockInteraction.options.getInteger.mockReturnValueOnce(1);
+    const singleGame = captor<string>();
 
-describe('Random unique number', () => {
-  it('should return a unique number that is not in the array', async () => {
-    const number = getUniqueRandomIntInclusive([1, 2, 3], 1, 4);
-    expect(number).toEqual(4);
+    await powerball(mockInteraction);
+
+    expect(mockInteraction.reply).toHaveBeenCalledWith(singleGame);
+
+    const gameValue = singleGame.value.replaceAll('`', '');
+    const pbNumber = gameValue.substring(gameValue.indexOf(':') + 1);
+    const pbValue = Number.parseInt(pbNumber, 10);
+    expect(pbValue).lessThanOrEqual(20).greaterThanOrEqual(1);
   });
 });

--- a/src/commands/quoteOfTheDay/index.test.ts
+++ b/src/commands/quoteOfTheDay/index.test.ts
@@ -1,49 +1,46 @@
-import { vi, it, describe, expect } from 'vitest';
+import { it, describe, expect, beforeEach } from 'vitest';
 import { faker } from '@faker-js/faker';
-import { getQuoteOfTheDay } from '.';
 import { rest } from 'msw';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
+import { getQuoteOfTheDay } from '.';
 import { server } from '../../mocks/server';
 import { ZEN_QUOTES_URL } from './fetchQuote';
 
-const deferReplyMock = vi.fn();
-const editReplyMock = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('Get quote of the day test', () => {
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
+
   it('Should reply with error if it downloaded a blank array', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-    };
     const endpoint = rest.get(ZEN_QUOTES_URL, (_, res, ctx) => {
       return res(ctx.status(200), ctx.json([]));
     });
     server.use(endpoint);
 
     await getQuoteOfTheDay(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
-    expect(editReplyMock).toHaveBeenCalledWith('Error getting quotes');
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      'Error getting quotes'
+    );
   });
 
   it('Should reply with error message if it error while downloading quotes', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-    };
     const endpoint = rest.get(ZEN_QUOTES_URL, (_, res, ctx) => {
       return res(ctx.status(500), ctx.json(undefined));
     });
     server.use(endpoint);
 
     await getQuoteOfTheDay(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
-    expect(editReplyMock).toHaveBeenCalledWith('Error getting quotes');
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      'Error getting quotes'
+    );
   });
 
   it('Should reply with a random quote', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-    };
     const fakeQuote = faker.lorem.words(25);
     const sampleQuote = {
       q: fakeQuote,
@@ -56,6 +53,6 @@ describe('Get quote of the day test', () => {
     server.use(endpoint);
 
     await getQuoteOfTheDay(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
   });
 });

--- a/src/commands/referral/referralNew.test.ts
+++ b/src/commands/referral/referralNew.test.ts
@@ -1,4 +1,10 @@
-import { vi, it, describe, expect } from 'vitest';
+import { vi, it, describe, expect, beforeEach } from 'vitest';
+import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+} from 'discord.js';
+import { PrismaClient } from '@prisma/client';
 import { autocomplete, execute } from './referralNew';
 import { getPrismaClient } from '../../clients';
 import { services } from './services';
@@ -6,185 +12,176 @@ import { services } from './services';
 vi.mock('../../clients');
 const mockGetPrismaClient = vi.mocked(getPrismaClient);
 
+const mockAutocompleteInteraction = mockDeep<AutocompleteInteraction>();
+const mockChatInputInteraction = mockDeep<ChatInputCommandInteraction>();
+
 describe('autocomplete', () => {
-  it('should return nothing if the search term shorter than 4', () => {
-    // mock input options
-    const options = {
-      getString: (name: string, required: true) => {
-        expect(name).toBe('service');
-        expect(required).toBe(true);
-        return 'solve';
-      },
-    };
-
-    // expect response
-    const respond = (opts: any[]) => {
-      expect(opts).toHaveLength(1);
-    };
-
-    autocomplete({ options, respond } as any);
+  beforeEach(() => {
+    mockReset(mockAutocompleteInteraction);
   });
 
-  it('should return nothing if no options found', () => {
-    // mock input options
-    const options = {
-      getString: (name: string, required: true) => {
-        expect(name).toBe('service');
-        expect(required).toBe(true);
-        return 'some random search that not existed';
-      },
-    };
+  it('should return nothing if the search term shorter than 4', async () => {
+    mockAutocompleteInteraction.options.getString.mockReturnValueOnce('solve');
+    const respondInput =
+      captor<Parameters<AutocompleteInteraction['respond']>['0']>();
 
-    // expect respone
-    const respond = (opts: any[]) => {
-      expect(opts).toHaveLength(0);
-    };
+    await autocomplete(mockAutocompleteInteraction);
 
-    autocomplete({ options, respond } as any);
+    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
+    expect(respondInput.value.length).toEqual(1);
   });
 
-  it('should return some options if search term longer than 4 and found', () => {
-    // mock input options
-    const options = {
-      getString: (name: string, required: true) => {
-        expect(name).toBe('service');
-        expect(required).toBe(true);
-        return 'heal';
+  it('should return nothing if no options found', async () => {
+    mockAutocompleteInteraction.options.getString.mockReturnValueOnce(
+      'some random search that not existed'
+    );
+    const respondInput =
+      captor<Parameters<AutocompleteInteraction['respond']>['0']>();
+
+    await autocomplete(mockAutocompleteInteraction);
+
+    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
+    expect(respondInput.value.length).toEqual(0);
+  });
+
+  it('should return some options if search term longer than 4 and found', async () => {
+    mockAutocompleteInteraction.options.getString.mockReturnValueOnce('heal');
+    const respondInput =
+      captor<Parameters<AutocompleteInteraction['respond']>['0']>();
+
+    await autocomplete(mockAutocompleteInteraction);
+
+    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
+    expect(respondInput.value).toMatchInlineSnapshot(`
+    [
+      {
+        "name": "ahm health insurance",
+        "value": "ahm health insurance",
       },
-    };
-
-    // expect response
-    const respond = (opts: any[]) => {
-      expect(opts).toMatchInlineSnapshot(`
-        [
-          {
-            "name": "ahm health insurance",
-            "value": "ahm health insurance",
-          },
-          {
-            "name": "doctors' health fund",
-            "value": "doctors' health fund",
-          },
-          {
-            "name": "phoenix health fund",
-            "value": "phoenix health fund",
-          },
-          {
-            "name": "qantas insurance - health insurance",
-            "value": "qantas insurance - health insurance",
-          },
-          {
-            "name": "westfund health insurance",
-            "value": "westfund health insurance",
-          },
-        ]
-      `);
-    };
-
-    autocomplete({ options, respond } as any);
+      {
+        "name": "doctors' health fund",
+        "value": "doctors' health fund",
+      },
+      {
+        "name": "phoenix health fund",
+        "value": "phoenix health fund",
+      },
+      {
+        "name": "qantas insurance - health insurance",
+        "value": "qantas insurance - health insurance",
+      },
+      {
+        "name": "westfund health insurance",
+        "value": "westfund health insurance",
+      },
+    ]
+  `);
   });
 });
 
 describe('execute', () => {
-  it('should return no service error if service is not in services list', () => {
+  beforeEach(() => {
+    mockReset(mockChatInputInteraction);
+  });
+
+  it('should return no service error if service is not in services list', async () => {
     const service = 'not in the list';
-
-    // mock input options
-    const options = {
-      getString: (name: string, required: true) => {
+    mockChatInputInteraction.options.getString.mockImplementation(
+      (name, required) => {
         if (name === 'service') return service;
-        if (name === 'link_or_code') return;
+        if (name === 'link_or_code') return null;
         if (name === 'expiry_date' && required) return 'lol';
-      },
-    };
 
-    // expect response
-    const reply = (message: string) => {
-      expect(message).toBe(
-        `No service named ${service}, ask the admin to add it`
-      );
-    };
+        return null;
+      }
+    );
 
-    execute({ options, reply } as any);
+    await execute(mockChatInputInteraction);
+
+    expect(mockChatInputInteraction.reply).toBeCalledWith(
+      `No service named ${service}, ask the admin to add it`
+    );
   });
 
-  it('should return INVALID_DATE error', () => {
-    // mock input options
-    const options = {
-      getString: (name: string, required: true) => {
+  it('should return INVALID_DATE error', async () => {
+    mockChatInputInteraction.options.getString.mockImplementation(
+      (name, required) => {
         if (name === 'service') return services[0];
-        if (name === 'link_or_code') return;
+        if (name === 'link_or_code') return null;
         if (name === 'expiry_date' && required) return 'lol';
-      },
-    };
 
-    // expect response
-    const reply = (message: string) => {
-      expect(message).toBe('expiry_date is invalid date try format DD/MM/YYYY');
-    };
+        return null;
+      }
+    );
 
-    execute({ options, reply } as any);
+    await execute(mockChatInputInteraction);
+
+    expect(mockChatInputInteraction.reply).toBeCalledWith(
+      'expiry_date is invalid date try format DD/MM/YYYY'
+    );
   });
 
-  it('should return EXPIRED_DATE error', () => {
-    // mock input
-    const input: { [name: string]: any } = {
+  it('should return EXPIRED_DATE error', async () => {
+    const input: { [name: string]: string | null } = {
       service: services[0],
-      link_or_code: undefined,
+      link_or_code: null,
       expiry_date: '05/04/1994',
     };
-    const options = {
-      getString: (name: string) => input[name],
-    };
 
-    // expect reply
-    const reply = (message: string) => {
-      expect(message).toBe('expiry_date has already expired');
-    };
+    mockChatInputInteraction.options.getString.mockImplementation(
+      (name: string) => input[name]
+    );
 
-    execute({ options, reply } as any);
+    await execute(mockChatInputInteraction);
+
+    expect(mockChatInputInteraction.reply).toBeCalledWith(
+      'expiry_date has already expired'
+    );
   });
 
-  it('should create a new referral code', () => {
+  it('should create a new referral code', async () => {
     const data = {
       service: services[0],
       code: 'SomeCodeHere',
       expiry_date: `04/04/${new Date().getFullYear() + 1}`,
     };
 
-    const mockPrisma: any = {
-      referralCode: {
-        create: (input: any) => {
-          expect(input.data.service).toBe(data.service);
-          expect(input.data.code).toBe(data.code);
-          expect(input.data.expiry_date.toISOString()).toBe(
-            new Date(data.expiry_date).toISOString()
-          );
+    const mockPrismaClient = mockDeep<PrismaClient>();
+    const mockReferralInput = captor<{
+      data: { service: string; code: string; expiry_date: Date };
+    }>();
+    mockPrismaClient.referralCode.create.mockResolvedValueOnce({
+      id: '12345',
+      service: data.service,
+      code: data.code,
+      expiry_date: new Date(data.expiry_date),
+    });
+    mockGetPrismaClient.mockReturnValueOnce(mockPrismaClient);
 
-          return {
-            service: data.service,
-            code: data.code,
-            expiry_date: new Date(data.expiry_date),
-          };
-        },
-      },
-    };
-    mockGetPrismaClient.mockReturnValueOnce(mockPrisma);
-
-    // mock input options
-    const options = {
-      getString: (name: string, required: true) => {
+    mockChatInputInteraction.options.getString.mockImplementation(
+      (name: string, required?: boolean) => {
         if (name === 'service') return data.service;
         if (name === 'link_or_code') return data.code;
         if (name === 'expiry_date' && required) return data.expiry_date;
-      },
-    };
 
-    // expect response
-    const reply = (message: string) => {
-      expect(message).toContain('new SomeCodeHere in 3commas');
-    };
+        return null;
+      }
+    );
+    const replyInput = captor<string>();
 
-    execute({ options, reply } as any);
+    await execute(mockChatInputInteraction);
+
+    expect(mockPrismaClient.referralCode.create).toBeCalledWith(
+      mockReferralInput
+    );
+    const input = mockReferralInput.value;
+    expect(input.data.service).toBe(data.service);
+    expect(input.data.code).toBe(data.code);
+    expect(input.data.expiry_date.toISOString()).toBe(
+      new Date(data.expiry_date).toISOString()
+    );
+
+    expect(mockChatInputInteraction.reply).toBeCalledWith(replyInput);
+    expect(replyInput.value).toContain('new SomeCodeHere in 3commas');
   });
 });

--- a/src/commands/reminder/remove.test.ts
+++ b/src/commands/reminder/remove.test.ts
@@ -1,62 +1,41 @@
-import { vi, it, describe, expect } from 'vitest';
+import { vi, it, describe, expect, beforeEach } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { removeReminder } from './reminder-utils';
 import { execute } from './remove';
 
 vi.mock('./reminder-utils');
 const mockRemoveReminder = vi.mocked(removeReminder);
-const replyMock = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
-const userId = 'user_12345';
-const guildId = 'guild_12345';
 const reminderId = '1';
 
-const mockGetString = () => reminderId;
-
 describe('Remove Reminder', () => {
+  beforeEach(() => {
+    mockReset(mockInteraction);
+    mockInteraction.options.getString.mockReturnValueOnce(reminderId);
+  });
+
   it('Should reply with error if reminders cannot be removed', async () => {
     mockRemoveReminder.mockRejectedValueOnce(new Error('Synthetic error'));
-    const mockInteraction: any = {
-      reply: replyMock,
-      member: {
-        user: {
-          id: userId,
-        },
-      },
-      guildId,
-      options: {
-        getString: mockGetString,
-      },
-    };
 
     await execute(mockInteraction);
 
-    expect(mockRemoveReminder).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockRemoveReminder).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       `Cannot delete reminder id ${reminderId}. Please try again later.`
     );
   });
 
   it('Should reply if reminder can be removed', async () => {
     mockRemoveReminder.mockResolvedValueOnce();
-    const mockInteraction: any = {
-      reply: replyMock,
-      member: {
-        user: {
-          id: userId,
-        },
-      },
-      guildId,
-      options: {
-        getString: mockGetString,
-      },
-    };
 
     await execute(mockInteraction);
 
-    expect(mockRemoveReminder).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockRemoveReminder).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       `Reminder ${reminderId} has been deleted.`
     );
   });

--- a/src/commands/reputation/checkReputation.test.ts
+++ b/src/commands/reputation/checkReputation.test.ts
@@ -1,29 +1,28 @@
-import { vi, it, describe, expect } from 'vitest';
+import { vi, it, describe, expect, beforeEach } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { checkReputation } from './checkReputation';
 import { getOrCreateUser } from './_helpers';
 
 vi.mock('./_helpers');
 const mockGetOrCreateUser = vi.mocked(getOrCreateUser);
-const replyMock = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('checkReputation', () => {
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
+
   it('should send reply if message is "-rep"', async () => {
     mockGetOrCreateUser.mockResolvedValueOnce({
       id: '1',
       reputation: 0,
     });
-    const mockInteraction: any = {
-      reply: replyMock,
-      member: {
-        user: {
-          id: '1',
-        },
-      },
-    };
+    mockInteraction.member!.user.id = '1';
 
     await checkReputation(mockInteraction);
 
-    expect(mockGetOrCreateUser).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(mockGetOrCreateUser).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
   });
 });

--- a/src/commands/reputation/takeReputation.test.ts
+++ b/src/commands/reputation/takeReputation.test.ts
@@ -1,5 +1,6 @@
-import { vi, it, describe, expect } from 'vitest';
-import { Collection, GuildMember, User } from 'discord.js';
+import { vi, it, describe, expect, beforeEach } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction, GuildMember, User } from 'discord.js';
 import { takeReputation } from './takeReputation';
 import { getOrCreateUser, updateRep } from './_helpers';
 import { isAdmin } from '../../utils';
@@ -11,88 +12,65 @@ const mockUpdateRep = vi.mocked(updateRep);
 vi.mock('../../utils/isSentFromAdmin');
 const mockIsSentFromAdmin = vi.mocked(isAdmin);
 
-const replyMock = vi.fn(() => {});
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('takeRep', () => {
   beforeAll(() => {
     mockIsSentFromAdmin.mockReturnValue(true);
   });
 
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
+
   it('should reply with an error message if the user is not an admin', async () => {
     mockIsSentFromAdmin.mockReturnValueOnce(false);
-    const mockInteraction: any = {
-      reply: replyMock,
-      options: {},
-      guild: {},
-      member: {},
-    };
 
     await takeReputation(mockInteraction);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(replyMock).toHaveBeenCalled();
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.reply).toHaveBeenCalled();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       "You don't have enough permission to run this command."
     );
   });
 
   it('should send a message if the user has 0 rep', async () => {
-    const mockUser = { id: '0' } as User;
     mockCreateUpdateUser
       .mockResolvedValueOnce({ id: '1', reputation: 0 })
       .mockResolvedValueOnce({ id: '0', reputation: 0 });
-    const mockInteraction: any = {
-      reply: replyMock,
-      member: {
-        user: {
-          id: '1',
-        },
-      },
-      options: {
-        getUser: vi.fn(() => mockUser),
-      },
-    };
+    const mockUser = { id: '0' } as User;
+    mockInteraction.member!.user.id = '1';
+    mockInteraction.options.getUser.mockReturnValueOnce(mockUser);
 
     await takeReputation(mockInteraction);
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(replyMock).toHaveBeenCalledWith('<@0> currently has 0 rep');
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      '<@0> currently has 0 rep'
+    );
   });
 
   it('Should call reply when user mentions another user', async () => {
-    const mockUser = { id: '0' } as User;
     mockCreateUpdateUser
       .mockResolvedValueOnce({ id: '1', reputation: 10 })
       .mockResolvedValueOnce({ id: '0', reputation: 10 });
     mockUpdateRep.mockResolvedValueOnce({ id: '0', reputation: 0 });
-    const mockUserCollection = new Collection<string, GuildMember>();
-    mockUserCollection.set('1', { displayName: 'test1' } as GuildMember);
-    mockUserCollection.set('0', { displayName: 'test0' } as GuildMember);
-    const mockInteraction: any = {
-      reply: replyMock,
-      member: {
-        user: {
-          id: '1',
-        },
-      },
-      options: {
-        getUser: vi.fn(() => mockUser),
-      },
-      guild: {
-        members: {
-          cache: mockUserCollection,
-        },
-      },
-    };
+    const mockUser = { id: '0' } as User;
+    mockInteraction.guild!.members.cache.get.mockImplementation((key) => {
+      return { displayName: `test${key}` } as GuildMember;
+    });
+    mockInteraction.member!.user.id = '1';
+    mockInteraction.options.getUser.mockReturnValueOnce(mockUser);
 
     await takeReputation(mockInteraction);
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
-    expect(mockUpdateRep).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(replyMock).toHaveBeenCalledWith(
+    expect(mockUpdateRep).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       'test1 took 1 rep from test0.\ntest0 → 0 reps'
     );
   });

--- a/src/commands/serverSettings/set-reminder-channel.test.ts
+++ b/src/commands/serverSettings/set-reminder-channel.test.ts
@@ -1,56 +1,45 @@
-import { vi, it, describe, expect } from 'vitest';
+import { vi, it, describe, expect, beforeEach } from 'vitest';
+import { mockReset, mockDeep } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction, TextChannel } from 'discord.js';
 import { execute } from './set-reminder-channel';
 import { setReminderChannel } from './server-utils';
 
 vi.mock('./server-utils');
 const mockSetReminderChannel = vi.mocked(setReminderChannel);
-const mockReply = vi.fn();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const channelId = 'channel_12345';
-const guildId = 'guild_12345';
 
 describe('Set reminder channel', () => {
+  beforeEach(() => {
+    mockReset(mockInteraction);
+  });
+
   it('Should reply with error if it cannot set the channel', async () => {
     mockSetReminderChannel.mockRejectedValueOnce(new Error('Synthetic Error'));
-    const mockInteraction: any = {
-      reply: mockReply,
-      guildId,
-      options: {
-        getChannel() {
-          return {
-            id: channelId,
-          };
-        },
-      },
-    };
+    mockInteraction.options.getChannel.mockReturnValueOnce({
+      id: channelId,
+    } as TextChannel);
 
     await execute(mockInteraction);
 
     expect(mockSetReminderChannel).toHaveBeenCalledOnce();
-    expect(mockReply).toHaveBeenCalledOnce();
-    expect(mockReply).toHaveBeenCalledWith(
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       'Cannot save this reminder channel for this server. Please try again.'
     );
   });
 
   it('Should be able to set channel and reply', async () => {
     mockSetReminderChannel.mockResolvedValueOnce(channelId);
-    const mockInteraction: any = {
-      reply: mockReply,
-      guildId,
-      options: {
-        getChannel() {
-          return {
-            id: channelId,
-          };
-        },
-      },
-    };
+    mockInteraction.options.getChannel.mockReturnValueOnce({
+      id: channelId,
+    } as TextChannel);
 
     await execute(mockInteraction);
 
     expect(mockSetReminderChannel).toHaveBeenCalledOnce();
-    expect(mockReply).toHaveBeenCalledOnce();
-    expect(mockReply).toHaveBeenCalledWith(
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
       `Sucessfully saved setting. Reminders will be broadcasted in <#${channelId}>`
     );
   });

--- a/src/commands/weather/index.test.ts
+++ b/src/commands/weather/index.test.ts
@@ -1,13 +1,15 @@
-import { vi, it, describe, expect } from 'vitest';
+import { it, describe, expect, beforeEach } from 'vitest';
 import { faker } from '@faker-js/faker';
 import { rest } from 'msw';
+import { mockReset, mockDeep } from 'vitest-mock-extended';
+import { ChatInputCommandInteraction } from 'discord.js';
 import { weather } from '.';
 import { server } from '../../mocks/server';
 import { WEATHER_URL } from './fetchWeather';
 
-const deferReplyMock = vi.fn();
-const editReplyMock = vi.fn();
 const mockWeatherMessage = faker.lorem.words(10);
+
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('Weather test', () => {
   beforeEach(() => {
@@ -19,72 +21,50 @@ describe('Weather test', () => {
       return res(ctx.status(200), ctx.text(mockWeatherMessage));
     });
     server.use(endpoint);
+
+    mockReset(mockInteraction);
   });
 
   it('Should reply command with weather data', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-      options: {
-        getString: vi.fn(() => 'Hanoi'),
-      },
-    };
+    mockInteraction.options.getString.mockReturnValueOnce('Hanoi');
 
     await weather(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
-    expect(editReplyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
       `\`\`\`\n${mockWeatherMessage}\n\`\`\``
     );
   });
 
   it('Should run with default input if no input is given', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-      options: {
-        getString: vi.fn(() => ''),
-      },
-    };
+    mockInteraction.options.getString.mockReturnValueOnce('');
 
     await weather(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
-    expect(editReplyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
       `\`\`\`\n${mockWeatherMessage}\n\`\`\``
     );
   });
 
   it('Should reply with error if given an error location', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-      options: {
-        getString: vi.fn(() => 'ErrorLocation'),
-      },
-    };
+    mockInteraction.options.getString.mockReturnValueOnce('ErrorLocation');
 
     await weather(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
-    expect(editReplyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
       'Error getting weather data for location.'
     );
   });
 
   it('Should reply with error if input is valid but weather data cannot be downloaded', async () => {
-    const mockInteraction: any = {
-      deferReply: deferReplyMock,
-      editReply: editReplyMock,
-      options: {
-        getString: vi.fn(() => 'Brisbane'),
-      },
-    };
+    mockInteraction.options.getString.mockReturnValueOnce('Brisbane');
     const endpoint = rest.get(`${WEATHER_URL}:location`, (_, res, ctx) => {
       return res(ctx.status(500), ctx.json(undefined));
     });
     server.use(endpoint);
 
     await weather(mockInteraction);
-    expect(editReplyMock).toHaveBeenCalledTimes(1);
-    expect(editReplyMock).toHaveBeenCalledWith(
+    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
       'Error getting weather data for location.'
     );
   });

--- a/src/utils/random/index.test.ts
+++ b/src/utils/random/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { getUniqueRandomIntInclusive } from '.';
+
+describe('Random unique number', () => {
+  it('should return a unique number that is not in the array', async () => {
+    const number = getUniqueRandomIntInclusive([1, 2, 3], 1, 4);
+    expect(number).toEqual(4);
+  });
+});


### PR DESCRIPTION
## Description

- Replace manual any test mocks with `Interaction` and `Message` object
proxy
- Replace `toHaveBeenCalledTimes(1)` with `toHaveBeenCalledOnce()`
- Replace `toHaveBeenCalledTimes(0)` with `not.toHaveBeenCalled()`

## Motivation and Context

Previously, manual object test mocks has been very confusing, and the
devs working on this repo just keep on copy pasting without actually
understanding why and how the manual mock works.

This will make the process a lot more automatic, also making it behave
more like DiscordJS itself.

## Related Issue

Resolves #157 

## How Has This Been Tested?

Since this is just tests and no functionality changes, all new unit tests have been ran and verified all green.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
