### PR TITLE
Fix Clean up Referrals container name

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -42,6 +42,6 @@ services:
     depends_on:
       - db
     image: ghcr.io/viet-aus-it/discord-bot:production
-    container_name: autobump_prod
+    container_name: cleanup_referrals_prod
     env_file: ".env.production"
     command: ["--enable-source-maps", "build/server/cleanup-expired-referrals.js"]


### PR DESCRIPTION
Currently this will create a collision on prod because another container has the name `autobump_prod` already.