### PR TITLE
hotfix: Fix weather fetching output not text but in HTML

### DIFF
--- a/src/commands/weather/fetchWeather.ts
+++ b/src/commands/weather/fetchWeather.ts
@@ -7,6 +7,7 @@ const weatherApi = wretch(WEATHER_URL);
 
 export const fetchWeather = async (where: string) => {
   const response = await weatherApi
+    .headers({ 'User-Agent': 'curl', 'Content-Type': 'text/plain' })
     .get(where + ARGUMENTS)
     .text()
     .catch((err) => {


### PR DESCRIPTION
The Weather API checks for the user agent of the caller. If it's
curl, it then will return the text format that will fit in the
terminal, which we then use as the output of the weather command,
or else, it will then fetch the page as HTML, which will then break
the text limit of 2000 chars or less of Discord.

This will resolve this issue.
