### PR TITLE
feat: remove timestamp from logs

### DIFF
--- a/src/autobump.ts
+++ b/src/autobump.ts
@@ -1,25 +1,23 @@
-import { getUnixTime } from 'date-fns';
 import { ThreadChannel } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDiscordClient } from './clients';
 import { listAllThreads } from './commands/autobump-threads/util';
-import { getCurrentUnixTime } from './utils/dateUtils';
 import { loadEnv } from './utils/loadEnv';
 import { logger } from './utils/logger';
 
 const autobump = async () => {
   loadEnv();
-  logger.info(`AUTOBUMPING THREADS. TIMESTAMP: ${getUnixTime(new Date())}`);
+  logger.info('AUTOBUMPING THREADS');
 
   const settings = await Result.safe(listAllThreads());
   if (settings.isErr()) {
-    logger.error(`[autobump]: Cannot retrieve autobump thread lists. Timestamp: ${getCurrentUnixTime()}`);
+    logger.error('[autobump]: Cannot retrieve autobump thread lists');
     process.exit(1);
   }
 
   const data = settings.unwrap();
   if (data.length === 0) {
-    logger.info(`[autobump]: No autobump threads settings found. Timestamp: ${getCurrentUnixTime()}`);
+    logger.info('[autobump]: No autobump threads settings found');
     process.exit(0);
   }
 
@@ -30,7 +28,7 @@ const autobump = async () => {
     async (accumulator, { guildId, autobumpThreads }) => {
       const guild = client.guilds.cache.find((g) => g.available && g.id === guildId);
       if (!guild) {
-        logger.info(`[autobump]: Cannot find guild ${guildId} for autobump. Timestamp: ${getCurrentUnixTime()}`);
+        logger.info(`[autobump]: Cannot find guild ${guildId} for autobump`);
         return accumulator;
       }
 
@@ -47,7 +45,7 @@ const autobump = async () => {
     Promise.resolve([] as unknown[])
   );
 
-  logger.info(`[autobump]: Thread autobump complete. Jobs: ${jobs.length}. Timestamp: ${getCurrentUnixTime()}`);
+  logger.info(`[autobump]: Thread autobump complete. Jobs: ${jobs.length}`);
   process.exit(0);
 };
 

--- a/src/broadcast-reminder.ts
+++ b/src/broadcast-reminder.ts
@@ -10,18 +10,18 @@ import { logger } from './utils/logger';
 
 const broadcastReminder = async () => {
   loadEnv();
-  logger.info(`BROADCASTING REMINDERS. TIMESTAMP: ${getUnixTime(new Date())}`);
+  logger.info('BROADCASTING REMINDERS');
 
   const queryTime = getCurrentUnixTime();
   const reminders = await Result.safe(getReminderByTime(getCurrentUnixTime()));
   if (reminders.isErr()) {
-    logger.error(`[broadcast-reminder]: Cannot retrieve reminders. Timestamp: ${getCurrentUnixTime()}. Query Time: ${queryTime}`);
+    logger.error(`[broadcast-reminder]: Cannot retrieve reminders. Query Time: ${queryTime}`);
     process.exit(1);
   }
 
   const remindersData = reminders.unwrap();
   if (remindersData.length === 0) {
-    logger.info(`[broadcast-reminder]: No reminders to broadcast. Timestamp: ${getCurrentUnixTime()}. Query Time: ${queryTime}`);
+    logger.info(`[broadcast-reminder]: No reminders to broadcast. Query Time: ${queryTime}`);
     process.exit(0);
   }
 
@@ -32,30 +32,28 @@ const broadcastReminder = async () => {
     async (accumulator, reminder) => {
       const guild = client.guilds.cache.find((g) => g.available && g.id === reminder.guildId);
       if (!guild) {
-        logger.info(`[broadcast-reminder]: Cannot find guild ${reminder.guildId} for reminder. Timestamp: ${getCurrentUnixTime()}`);
+        logger.info(`[broadcast-reminder]: Cannot find guild ${reminder.guildId} for reminder`);
         return accumulator;
       }
 
       const channelId = await Result.safe(getReminderChannel(guild.id));
       if (channelId.isErr()) {
-        logger.info(`[broadcast-reminder]: Cannot find reminder channel settings for guild ${reminder.guildId}. Timestamp: ${getCurrentUnixTime()}`);
+        logger.info(`[broadcast-reminder]: Cannot find reminder channel settings for guild ${reminder.guildId}`);
         return accumulator;
       }
 
       const data = channelId.unwrap();
       if (!data) {
-        logger.info(`[broadcast-reminder]: Cannot unwrap reminder channel for guild ${reminder.guildId}. Timestamp: ${getCurrentUnixTime()}`);
+        logger.info(`[broadcast-reminder]: Cannot unwrap reminder channel for guild ${reminder.guildId}`);
         return accumulator;
       }
       const channel = client.channels.cache.get(data);
       if (!channel) {
-        logger.info(`[broadcast-reminder]: Cannot find reminder channel id ${data} for guild ${reminder.guildId}. Timestamp: ${getCurrentUnixTime()}`);
+        logger.info(`[broadcast-reminder]: Cannot find reminder channel id ${data} for guild ${reminder.guildId}`);
         return accumulator;
       }
       if (channel.type !== ChannelType.GuildText) {
-        logger.info(
-          `[broadcast-reminder]: Reminder channel id ${data} for guild ${reminder.guildId} is not a text channel. Timestamp: ${getCurrentUnixTime()}`
-        );
+        logger.info(`[broadcast-reminder]: Reminder channel id ${data} for guild ${reminder.guildId} is not a text channel`);
         return accumulator;
       }
 
@@ -73,7 +71,7 @@ const broadcastReminder = async () => {
 
   await removeReminders(remindersData);
 
-  logger.info(`[broadcast-reminder]: Reminders fan out complete. Jobs: ${jobs.length}. Timestamp: ${getCurrentUnixTime()}`);
+  logger.info(`[broadcast-reminder]: Reminders fan out complete. Jobs: ${jobs.length}`);
   process.exit(0);
 };
 

--- a/src/cleanup-expired-referrals.ts
+++ b/src/cleanup-expired-referrals.ts
@@ -7,15 +7,15 @@ import { logger } from './utils/logger';
 
 const cleanup = async () => {
   loadEnv();
-  logger.info(`[cleanup-expired-referrals]: CLEANING UP EXPIRED REFERRALS. Current Timestamp: ${getCurrentUnixTime()}`);
+  logger.info('[cleanup-expired-referrals]: CLEANING UP EXPIRED REFERRALS');
 
   const op = await Result.safe(cleanupExpiredCode());
   if (op.isErr()) {
-    logger.error(`[cleanup-expired-referrals]: Error cleaning up expired referrals. timestamp: ${getCurrentUnixTime()}`);
+    logger.error('[cleanup-expired-referrals]: Error cleaning up expired referrals');
     process.exit(1);
   }
 
-  logger.info(`[cleanup-expired-referrals]: Removed expired referrals. Timestamp: ${getCurrentUnixTime()}`);
+  logger.info('[cleanup-expired-referrals]: Removed expired referrals');
   process.exit(0);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { logger } from './utils/logger';
 
 const main = async () => {
   loadEnv();
-  logger.info(`[main]: STARTING BOT. TIMESTAMP: ${getCurrentUnixTime()}`);
+  logger.info('[main]: STARTING BOT');
   const token = process.env.TOKEN ?? '';
   const client = await getDiscordClient({ token });
 
@@ -21,7 +21,7 @@ const main = async () => {
   if (process.env.NODE_ENV === 'production') {
     // This should only be run once during the bot startup in production.
     // For development usage, please use `pnpm deploy:command`
-    logger.info(`[main]: Deploying global commands. Timestamp: ${getCurrentUnixTime()}`);
+    logger.info('[main]: Deploying global commands');
     const op = await Result.safe(
       deployGlobalCommands(commandList, contextMenuCommandList, {
         token,
@@ -29,10 +29,10 @@ const main = async () => {
       })
     );
     if (op.isErr()) {
-      logger.error(`[main]: Cannot deploy global commands. Timestamp: ${getCurrentUnixTime()}`, op.unwrapErr());
+      logger.error('[main]: Cannot deploy global commands', op.unwrapErr());
       process.exit(1);
     }
-    logger.info(`[main]: Successfully deployed global commands. Timestamp: ${getCurrentUnixTime()}`);
+    logger.info('[main]: Successfully deployed global commands');
   }
 
   const configs = getConfigs();
@@ -45,7 +45,7 @@ const main = async () => {
       const isCommand = interaction.isChatInputCommand();
       if (isCommand) {
         const { commandName } = interaction;
-        logger.info(`[main]: RECEIVED COMMAND. COMMAND: ${commandName}. TIMESTAMP: ${getCurrentUnixTime()}.`);
+        logger.info(`[main]: RECEIVED COMMAND. COMMAND: ${commandName}`);
         const command = commandList.find((cmd) => cmd.data.name === commandName);
         return await command?.execute(interaction);
       }
@@ -53,7 +53,7 @@ const main = async () => {
       const isContextMenuCommand = interaction.isContextMenuCommand();
       if (isContextMenuCommand) {
         const { commandName } = interaction;
-        logger.info(`[main]: RECEIVED CONTEXT MENU COMMAND. COMMAND: ${commandName}. TIMESTAMP: ${getCurrentUnixTime()}.`);
+        logger.info(`[main]: RECEIVED CONTEXT MENU COMMAND. COMMAND: ${commandName}`);
         const command = contextMenuCommandList.find((cmd) => cmd.data.name === commandName);
         return await command?.execute(interaction);
       }
@@ -61,12 +61,12 @@ const main = async () => {
       const isAutocomplete = interaction.type === InteractionType.ApplicationCommandAutocomplete;
       if (isAutocomplete) {
         const { commandName } = interaction;
-        logger.info(`[main]: RECEIVED AUTOCOMPLETE. COMMAND: ${commandName}. TIMESTAMP: ${getCurrentUnixTime()}.`);
+        logger.info(`[main]: RECEIVED AUTOCOMPLETE. COMMAND: ${commandName}`);
         const command = commandList.find((cmd) => cmd.data.name === commandName);
         return await command?.autocomplete?.(interaction);
       }
     } catch (error) {
-      logger.error(`[main]: ERROR HANDLING INTERACTION. TIMESTAMP: ${getCurrentUnixTime()}, ERROR: ${error}.`);
+      logger.error(`[main]: ERROR HANDLING INTERACTION, ERROR: ${error}`);
     }
   });
 };

--- a/src/scripts/delete-global-commands.ts
+++ b/src/scripts/delete-global-commands.ts
@@ -9,7 +9,7 @@ const deploy = async () => {
   const token = process.env.TOKEN ?? '';
   const clientId = process.env.CLIENT_ID ?? '';
 
-  logger.info(`[delete-global-commands]: Deleting global commands. Timestamp: ${getCurrentUnixTime()}.`);
+  logger.info('[delete-global-commands]: Deleting global commands');
   const op = await Result.safe(
     deployGlobalCommands([], [], {
       token,
@@ -17,11 +17,11 @@ const deploy = async () => {
     })
   );
   if (op.isOk()) {
-    logger.info(`[delete-global-commands]: Global commands deleted successfully. Timestamp: ${getCurrentUnixTime()}.`);
+    logger.info('[delete-global-commands]: Global commands deleted successfully');
     process.exit(0);
   }
 
-  logger.error(`[delete-global-commands]: Cannot delete global commands. Timestamp: ${getCurrentUnixTime()}`, op.unwrapErr());
+  logger.error('[delete-global-commands]: Cannot delete global commands', op.unwrapErr());
   process.exit(1);
 };
 

--- a/src/scripts/delete-guild-commands.ts
+++ b/src/scripts/delete-guild-commands.ts
@@ -10,7 +10,7 @@ const deploy = async () => {
   const clientId = process.env.CLIENT_ID ?? '';
   const guildId = process.env.GUILD_ID ?? '';
 
-  logger.info(`[delete-guild-commands]: Deleting guild commands. Timestamp: ${getCurrentUnixTime()}`);
+  logger.info('[delete-guild-commands]: Deleting guild commands');
   const op = await Result.safe(
     deployGuildCommands([], [], {
       token,
@@ -19,7 +19,7 @@ const deploy = async () => {
     })
   );
   if (op.isOk()) {
-    logger.info(`[delete-guild-commands]: Guild commands deleted successfully. Timestamp: ${getCurrentUnixTime()}`);
+    logger.info('[delete-guild-commands]: Guild commands deleted successfully');
     process.exit(0);
   }
 

--- a/src/scripts/deploy-guild-commands.ts
+++ b/src/scripts/deploy-guild-commands.ts
@@ -11,7 +11,7 @@ const deploy = async () => {
   const clientId = process.env.CLIENT_ID ?? '';
   const guildId = process.env.GUILD_ID ?? '';
 
-  logger.info(`[deploy-guild-commands]: Deploying guild commands. Timestamp: ${getCurrentUnixTime()}`);
+  logger.info('[deploy-guild-commands]: Deploying guild commands');
   const op = await Result.safe(
     deployGuildCommands(commandList, contextMenuCommandList, {
       token,
@@ -20,7 +20,7 @@ const deploy = async () => {
     })
   );
   if (op.isOk()) {
-    logger.info(`[deploy-guild-commands]: Guild commands deployed successfully. Timestamp: ${getCurrentUnixTime()}`);
+    logger.info('[deploy-guild-commands]: Guild commands deployed successfully');
     process.exit(0);
   }
 

--- a/src/utils/messageProcessor/index.ts
+++ b/src/utils/messageProcessor/index.ts
@@ -35,6 +35,6 @@ export const processMessage = async (message: Message, config: CommandConfig) =>
   try {
     await Promise.all(keywordPromises);
   } catch (error) {
-    logger.error(`ERROR PROCESSING MESSAGE. TIMESTAMP: ${getCurrentUnixTime()}`, error);
+    logger.error('ERROR PROCESSING MESSAGE', error);
   }
 };


### PR DESCRIPTION
This is because winston log transports already have timestamps

Sample of redundant timestamp:
![image](https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/4283a763-0336-4f31-bb45-10d8a4a656da)
