### PR TITLE
feat: rename prisma client to db

### DIFF
--- a/src/clients/prisma.ts
+++ b/src/clients/prisma.ts
@@ -17,4 +17,4 @@ if (process.env.NODE_ENV === 'production') {
   prisma = new PrismaClient();
 }
 
-export const getPrismaClient = () => prisma;
+export const getDbClient = () => prisma;

--- a/src/commands/autobump-threads/util.ts
+++ b/src/commands/autobump-threads/util.ts
@@ -1,8 +1,8 @@
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 
 export const addAutobumpThread = async (guildId: string, threadId: string) => {
-  const prisma = getPrismaClient();
-  const settings = await prisma.serverChannelsSettings.upsert({
+  const db = getDbClient();
+  const settings = await db.serverChannelsSettings.upsert({
     where: { guildId },
     update: {
       autobumpThreads: {
@@ -19,12 +19,12 @@ export const addAutobumpThread = async (guildId: string, threadId: string) => {
 };
 
 export const removeAutobumpThread = async (guildId: string, threadId: string) => {
-  const prisma = getPrismaClient();
-  const { autobumpThreads } = await prisma.serverChannelsSettings.findFirstOrThrow({
+  const db = getDbClient();
+  const { autobumpThreads } = await db.serverChannelsSettings.findFirstOrThrow({
     where: { guildId },
   });
 
-  const settings = await prisma.serverChannelsSettings.update({
+  const settings = await db.serverChannelsSettings.update({
     where: { guildId },
     data: {
       autobumpThreads: autobumpThreads.filter((t) => t !== threadId),
@@ -35,8 +35,8 @@ export const removeAutobumpThread = async (guildId: string, threadId: string) =>
 };
 
 export const listThreadsByGuild = async (guildId: string) => {
-  const prisma = getPrismaClient();
-  const settings = await prisma.serverChannelsSettings.findFirstOrThrow({
+  const db = getDbClient();
+  const settings = await db.serverChannelsSettings.findFirstOrThrow({
     where: { guildId },
   });
 
@@ -44,8 +44,8 @@ export const listThreadsByGuild = async (guildId: string) => {
 };
 
 export const listAllThreads = async () => {
-  const prisma = getPrismaClient();
-  const settings = await prisma.serverChannelsSettings.findMany({
+  const db = getDbClient();
+  const settings = await db.serverChannelsSettings.findMany({
     select: {
       guildId: true,
       autobumpThreads: true,

--- a/src/commands/referral/cleanupExpiredCode.ts
+++ b/src/commands/referral/cleanupExpiredCode.ts
@@ -1,9 +1,9 @@
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 
 export const cleanupExpiredCode = async () => {
-  const prisma = getPrismaClient();
+  const db = getDbClient();
   const currentDate = new Date();
-  return prisma.referralCode.deleteMany({
+  return db.referralCode.deleteMany({
     where: {
       expiry_date: {
         lt: currentDate,

--- a/src/commands/referral/referralNew.test.ts
+++ b/src/commands/referral/referralNew.test.ts
@@ -2,12 +2,12 @@ import { PrismaClient } from '@prisma/client';
 import { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 import { autocomplete, execute } from './referralNew';
 import { services } from './services';
 
 vi.mock('../../clients');
-const mockGetPrismaClient = vi.mocked(getPrismaClient);
+const mockGetDbClient = vi.mocked(getDbClient);
 
 const mockAutocompleteInteraction = mockDeep<AutocompleteInteraction>();
 const mockChatInputInteraction = mockDeep<ChatInputCommandInteraction>();
@@ -136,7 +136,7 @@ describe('execute', () => {
       code: data.code,
       expiry_date: new Date(data.expiry_date),
     });
-    mockGetPrismaClient.mockReturnValueOnce(mockPrismaClient);
+    mockGetDbClient.mockReturnValueOnce(mockPrismaClient);
 
     mockChatInputInteraction.options.getString.mockImplementation((name: string, required?: boolean) => {
       if (name === 'service') return data.service;

--- a/src/commands/referral/referralNew.ts
+++ b/src/commands/referral/referralNew.ts
@@ -1,5 +1,5 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 import { logger } from '../../utils/logger';
 import { AutocompleteHandler, CommandHandler } from '../builder';
 import { parseDate } from './parseDate';
@@ -47,10 +47,10 @@ export const execute: CommandHandler = async (interaction) => {
     return;
   }
 
-  const prisma = getPrismaClient();
+  const db = getDbClient();
 
   try {
-    const newReferralCode = await prisma.referralCode.create({
+    const newReferralCode = await db.referralCode.create({
       data: {
         service,
         code,

--- a/src/commands/referral/referralRandom.test.ts
+++ b/src/commands/referral/referralRandom.test.ts
@@ -2,11 +2,11 @@ import { PrismaClient } from '@prisma/client';
 import { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 import { autocomplete, execute } from './referralRandom';
 
 vi.mock('../../clients');
-const mockGetPrismaClient = vi.mocked(getPrismaClient);
+const mockGetDbClient = vi.mocked(getDbClient);
 
 const mockAutocompleteInteraction = mockDeep<AutocompleteInteraction>();
 const mockChatInputInteraction = mockDeep<ChatInputCommandInteraction>();
@@ -79,7 +79,7 @@ describe('execute', () => {
       where: { service: { contains: string } };
     }>();
     mockPrismaClient.referralCode.findMany.mockResolvedValueOnce([]);
-    mockGetPrismaClient.mockReturnValueOnce(mockPrismaClient);
+    mockGetDbClient.mockReturnValueOnce(mockPrismaClient);
     mockChatInputInteraction.options.getString.mockReturnValueOnce(service);
     const replyInput = captor<string>();
 
@@ -107,7 +107,7 @@ describe('execute', () => {
         service,
       },
     ]);
-    mockGetPrismaClient.mockReturnValueOnce(mockPrismaClient);
+    mockGetDbClient.mockReturnValueOnce(mockPrismaClient);
     mockChatInputInteraction.options.getString.mockReturnValueOnce(service);
     const replyInput = captor<string>();
 

--- a/src/commands/referral/referralRandom.ts
+++ b/src/commands/referral/referralRandom.ts
@@ -1,5 +1,5 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 import { getRandomIntInclusive } from '../../utils';
 import { AutocompleteHandler, CommandHandler } from '../builder';
 import { searchServices } from './services';
@@ -21,8 +21,8 @@ export const autocomplete: AutocompleteHandler = async (interaction) => {
 export const execute: CommandHandler = async (interaction) => {
   const service = interaction.options.getString('service', true)?.trim().toLowerCase() ?? '';
 
-  const prisma = getPrismaClient();
-  const referrals = await prisma.referralCode.findMany({
+  const db = getDbClient();
+  const referrals = await db.referralCode.findMany({
     where: {
       service: {
         contains: service,

--- a/src/commands/reminder/reminder-utils.ts
+++ b/src/commands/reminder/reminder-utils.ts
@@ -1,6 +1,6 @@
 import { Reminder } from '@prisma/client';
 import { getUnixTime, isAfter, isEqual } from 'date-fns';
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 
 type SaveReminderInput = {
   userId: string;
@@ -14,8 +14,8 @@ export const saveReminder = async ({ userId, guildId, message, timestamp }: Save
     throw new Error('EXPIRED DATE');
   }
 
-  const prisma = getPrismaClient();
-  const reminder = await prisma.reminder.create({
+  const db = getDbClient();
+  const reminder = await db.reminder.create({
     data: {
       userId,
       guildId,
@@ -40,12 +40,12 @@ export const updateReminder = async ({ userId, guildId, reminderId, message, tim
     throw new Error('EXPIRED DATE');
   }
 
-  const prisma = getPrismaClient();
-  let reminder = await prisma.reminder.findFirstOrThrow({
+  const db = getDbClient();
+  let reminder = await db.reminder.findFirstOrThrow({
     where: { id: reminderId, userId, guildId },
   });
 
-  reminder = await prisma.reminder.update({
+  reminder = await db.reminder.update({
     where: {
       id: reminderId,
     },
@@ -59,8 +59,8 @@ export const updateReminder = async ({ userId, guildId, reminderId, message, tim
 };
 
 export const getUserReminders = async (userId: string, guildId: string) => {
-  const prisma = getPrismaClient();
-  const reminders = await prisma.reminder.findMany({
+  const db = getDbClient();
+  const reminders = await db.reminder.findMany({
     where: {
       userId,
       guildId,
@@ -79,8 +79,8 @@ type RemoveReminderInput = {
   reminderId: string;
 };
 export const removeReminder = async ({ userId, guildId, reminderId }: RemoveReminderInput) => {
-  const prisma = getPrismaClient();
-  await prisma.reminder.deleteMany({
+  const db = getDbClient();
+  await db.reminder.deleteMany({
     where: {
       id: reminderId,
       userId,
@@ -96,8 +96,8 @@ export const formatReminderMessage = ({ userId, message, onTimestamp }: Reminder
 };
 
 export const getReminderByTime = async (timestamp: number) => {
-  const prisma = getPrismaClient();
-  const reminders = await prisma.reminder.findMany({
+  const db = getDbClient();
+  const reminders = await db.reminder.findMany({
     where: {
       onTimestamp: {
         lte: timestamp,
@@ -109,8 +109,8 @@ export const getReminderByTime = async (timestamp: number) => {
 };
 
 export const removeReminders = async (reminders: Reminder[]) => {
-  const prisma = getPrismaClient();
-  await prisma.reminder.deleteMany({
+  const db = getDbClient();
+  await db.reminder.deleteMany({
     where: {
       id: {
         in: reminders.map((r) => r.id),

--- a/src/commands/reputation/_helpers.test.ts
+++ b/src/commands/reputation/_helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 import { getOrCreateUser, updateRep } from './_helpers';
 
 vi.mock('../../clients');
-const mockGetPrismaClient = vi.mocked(getPrismaClient);
+const mockGetDbClient = vi.mocked(getDbClient);
 
 describe('getOrCreateUser', () => {
   it('should return user if user is existed', async () => {
@@ -12,7 +12,7 @@ describe('getOrCreateUser', () => {
         findUnique: () => ({ id: '1' }),
       },
     };
-    mockGetPrismaClient.mockReturnValueOnce(mockPrisma);
+    mockGetDbClient.mockReturnValueOnce(mockPrisma);
 
     const user = await getOrCreateUser('1');
     expect(user.id).toBe('1');
@@ -25,7 +25,7 @@ describe('getOrCreateUser', () => {
         create: () => ({ id: '1' }),
       },
     };
-    mockGetPrismaClient.mockReturnValueOnce(mockPrisma);
+    mockGetDbClient.mockReturnValueOnce(mockPrisma);
 
     const user = await getOrCreateUser('1');
     expect(user.id).toBe('1');
@@ -66,7 +66,7 @@ describe('updateRep', () => {
         },
       ],
     };
-    mockGetPrismaClient.mockReturnValueOnce(mockPrisma);
+    mockGetDbClient.mockReturnValueOnce(mockPrisma);
 
     const result = await updateRep({
       fromUserId: '2',

--- a/src/commands/serverSettings/server-utils.ts
+++ b/src/commands/serverSettings/server-utils.ts
@@ -1,8 +1,8 @@
-import { getPrismaClient } from '../../clients';
+import { getDbClient } from '../../clients';
 
 export const setReminderChannel = async (guildId: string, channelId: string) => {
-  const prisma = getPrismaClient();
-  const settings = await prisma.serverChannelsSettings.upsert({
+  const db = getDbClient();
+  const settings = await db.serverChannelsSettings.upsert({
     where: {
       guildId,
     },
@@ -19,8 +19,8 @@ export const setReminderChannel = async (guildId: string, channelId: string) => 
 };
 
 export const getReminderChannel = async (guildId: string) => {
-  const prisma = getPrismaClient();
-  const serverSettings = await prisma.serverChannelsSettings.findFirstOrThrow({
+  const db = getDbClient();
+  const serverSettings = await db.serverChannelsSettings.findFirstOrThrow({
     where: { guildId },
   });
 


### PR DESCRIPTION
Making the prisma module a more generic db client over explicitly calling it Prisma. This can aid further migrations efforts if we need to.