### PR TITLE
feat: Revamp Referral Process

### DIFF
--- a/prisma/migrations/20240307101727_add_owner_to_referral_code/migration.sql
+++ b/prisma/migrations/20240307101727_add_owner_to_referral_code/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - Added the required column `guildId` to the `ReferralCode` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `ReferralCode` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "ReferralCode_code_key";
+
+-- AlterTable
+ALTER TABLE "ReferralCode" ADD COLUMN     "guildId" TEXT NOT NULL,
+ADD COLUMN     "userId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "ReferralCode" ADD CONSTRAINT "ReferralCode_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,10 +16,11 @@ generator client {
 model User {
   id String @id
 
-  reputation Int             @default(0)
-  thankTo    ReputationLog[] @relation("FromUser")
-  thankBy    ReputationLog[] @relation("ToUser")
-  reminders  Reminder[]
+  reputation   Int             @default(0)
+  thankTo      ReputationLog[] @relation("FromUser")
+  thankBy      ReputationLog[] @relation("ToUser")
+  reminders    Reminder[]
+  ReferralCode ReferralCode[]
 }
 
 model ReputationLog {
@@ -35,8 +36,11 @@ model ReputationLog {
 model ReferralCode {
   id          String   @id @default(cuid())
   service     String
-  code        String   @unique
+  code        String
   expiry_date DateTime
+  guildId     String
+  userId      String
+  owner       User     @relation(fields: [userId], references: [id])
 }
 
 model Reminder {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,11 +16,11 @@ generator client {
 model User {
   id String @id
 
-  reputation   Int             @default(0)
-  thankTo      ReputationLog[] @relation("FromUser")
-  thankBy      ReputationLog[] @relation("ToUser")
-  reminders    Reminder[]
-  ReferralCode ReferralCode[]
+  reputation    Int             @default(0)
+  thankTo       ReputationLog[] @relation("FromUser")
+  thankBy       ReputationLog[] @relation("ToUser")
+  reminders     Reminder[]
+  referralCodes ReferralCode[]
 }
 
 model ReputationLog {

--- a/src/commands/referral/referralNew.test.ts
+++ b/src/commands/referral/referralNew.test.ts
@@ -79,6 +79,13 @@ describe('autocomplete', () => {
 describe('execute', () => {
   beforeEach(() => {
     mockReset(mockChatInputInteraction);
+    vi.useFakeTimers();
+    const date = new Date();
+    vi.setSystemTime(date);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should return no service error if service is not in services list', async () => {

--- a/src/commands/referral/referralNew.test.ts
+++ b/src/commands/referral/referralNew.test.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
+import { AutocompleteInteraction, ChatInputCommandInteraction, Guild } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
 import { getDbClient } from '../../clients';
@@ -124,6 +124,8 @@ describe('execute', () => {
       service: services[0],
       code: 'SomeCodeHere',
       expiry_date: `04/04/${new Date().getFullYear() + 1}`,
+      userId: '1234',
+      guildId: '12345',
     };
 
     const mockPrismaClient = mockDeep<PrismaClient>();
@@ -135,9 +137,13 @@ describe('execute', () => {
       service: data.service,
       code: data.code,
       expiry_date: new Date(data.expiry_date),
+      userId: data.userId,
+      guildId: data.guildId,
     });
     mockGetDbClient.mockReturnValueOnce(mockPrismaClient);
 
+    mockChatInputInteraction.user.id = data.userId;
+    (mockChatInputInteraction.guild as Guild).id = data.guildId;
     mockChatInputInteraction.options.getString.mockImplementation((name: string, required?: boolean) => {
       if (name === 'service') return data.service;
       if (name === 'link_or_code') return data.code;
@@ -156,6 +162,6 @@ describe('execute', () => {
     expect(input.data.expiry_date.toISOString()).toBe(new Date(data.expiry_date).toISOString());
 
     expect(mockChatInputInteraction.reply).toBeCalledWith(replyInput);
-    expect(replyInput.value).toContain(`new SomeCodeHere in ${services[0]}`);
+    expect(replyInput.value).toContain(`just added referral code SomeCodeHere in ${services[0]}`);
   });
 });

--- a/src/commands/referral/referralNew.ts
+++ b/src/commands/referral/referralNew.ts
@@ -69,6 +69,19 @@ export const execute: CommandHandler = async (interaction) => {
   const userId = interaction.user.id;
   const nickname = interaction.user.displayName;
 
+  const existingReferralCode = await db.referralCode.findFirst({
+    where: {
+      service,
+      userId,
+      guildId,
+    },
+  });
+  if (existingReferralCode) {
+    logger.error(`[referral-new]: Referral code for ${service} by ${nickname} already exists.`);
+    await interaction.reply(`You have already entered the referral code for ${service}.`);
+    return;
+  }
+
   try {
     const user = await getOrCreateUser(userId);
     const newReferralCode = await db.referralCode.create({

--- a/src/commands/referral/referralNew.ts
+++ b/src/commands/referral/referralNew.ts
@@ -1,4 +1,5 @@
-import { SlashCommandSubcommandBuilder } from 'discord.js';
+import { getUnixTime } from 'date-fns';
+import { Guild, SlashCommandSubcommandBuilder } from 'discord.js';
 import { getDbClient } from '../../clients';
 import { logger } from '../../utils/logger';
 import { AutocompleteHandler, CommandHandler } from '../builder';
@@ -48,6 +49,9 @@ export const execute: CommandHandler = async (interaction) => {
   }
 
   const db = getDbClient();
+  const guildId = (interaction.guild as Guild).id;
+  const userId = interaction.user.id;
+  const nickname = interaction.user.displayName;
 
   try {
     const newReferralCode = await db.referralCode.create({
@@ -55,10 +59,14 @@ export const execute: CommandHandler = async (interaction) => {
         service,
         code,
         expiry_date: parsedExpiryDate,
+        userId,
+        guildId,
       },
     });
 
-    await interaction.reply(`new ${newReferralCode.code} in ${newReferralCode.service} expired on ${newReferralCode.expiry_date.toDateString()}`);
+    await interaction.reply(
+      `${nickname} just added referral code ${newReferralCode.code} in ${newReferralCode.service} expired on <t:${getUnixTime(newReferralCode.expiry_date)}:D>`
+    );
   } catch (error) {
     logger.error('[referral-new]: Failed to add referral code.', error);
     await interaction.reply(

--- a/src/commands/referral/referralRandom.test.ts
+++ b/src/commands/referral/referralRandom.test.ts
@@ -105,6 +105,8 @@ describe('execute', () => {
         code,
         expiry_date: expiryDate,
         service,
+        userId: '12345',
+        guildId: '12345',
       },
     ]);
     mockGetDbClient.mockReturnValueOnce(mockPrismaClient);

--- a/src/commands/referral/referralRandom.ts
+++ b/src/commands/referral/referralRandom.ts
@@ -1,4 +1,4 @@
-import { SlashCommandSubcommandBuilder } from 'discord.js';
+import { Guild, SlashCommandSubcommandBuilder } from 'discord.js';
 import { getDbClient } from '../../clients';
 import { getRandomIntInclusive } from '../../utils';
 import { AutocompleteHandler, CommandHandler } from '../builder';
@@ -20,6 +20,7 @@ export const autocomplete: AutocompleteHandler = async (interaction) => {
 
 export const execute: CommandHandler = async (interaction) => {
   const service = interaction.options.getString('service', true)?.trim().toLowerCase() ?? '';
+  const guildId = (interaction.guild as Guild).id;
 
   const db = getDbClient();
   const referrals = await db.referralCode.findMany({

--- a/src/commands/referral/referralUtils.ts
+++ b/src/commands/referral/referralUtils.ts
@@ -1,0 +1,56 @@
+import { getDbClient } from '../../clients';
+import { getOrCreateUser } from '../reputation/_helpers';
+
+export type CreateReferralInput = {
+  userId: string;
+  guildId: string;
+  service: string;
+  code: string;
+  expiryDate: Date;
+};
+export const createReferralCode = async ({ userId, guildId, service, code, expiryDate }: CreateReferralInput) => {
+  const db = getDbClient();
+  await getOrCreateUser(userId);
+  return db.referralCode.create({
+    data: {
+      userId,
+      guildId,
+      service,
+      code,
+      expiry_date: expiryDate,
+    },
+  });
+};
+
+export type FindExistingReferralCodeInput = {
+  userId: string;
+  guildId: string;
+  service: string;
+};
+export const findExistingReferralCode = async ({ userId, guildId, service }: FindExistingReferralCodeInput) => {
+  const db = getDbClient();
+  return db.referralCode.findFirst({
+    where: {
+      userId,
+      guildId,
+      service,
+    },
+  });
+};
+
+export type GetAllReferralCodesForServiceInput = {
+  guildId: string;
+  service: string;
+};
+export const getAllReferralCodesForService = async ({ guildId, service }: GetAllReferralCodesForServiceInput) => {
+  const db = getDbClient();
+  return db.referralCode.findMany({
+    where: {
+      guildId,
+      service,
+      expiry_date: {
+        gte: new Date(),
+      },
+    },
+  });
+};


### PR DESCRIPTION
## Description

As already described in #205, at its current state, referrals are saved anonymously, which leads to a few issues. This referral aims to resolve that, but also added a few niceties.

- Update the `Referral` model to link to an owner `userId` that links to a `User`
- Update the `/referral new` command:
  - Update the response message to indicate who added the referral code
  - Add a dupe check logic to block a code if the user already added the code for said service
  - Make `expiry_date` an optional field. It will now default to 30 days from the added date.
- Update the `/referral random` message to also include the display name or the userid of the adder. This will help the end-user knows who to give rep when they use the code. 

## Motivation and Context

Resolves #205
Resolves #177 

## How Has This Been Tested?

- All existing and newly added unit tests passed
- Tested on the Bot Test server

## What's next?

This PR has to stay in draft for the time being so the admins can truncate the referrals table before this change can be migrated.

## Screenshots (if appropriate):

- Add new code
![Screenshot 2024-03-07 at 9 10 53 pm](https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/59d519d1-bc1d-4684-be60-270e05b8261b)
- Add new code with a defined expiry date
![Screenshot 2024-03-07 at 9 57 24 pm](https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/ff57c2a1-9a99-4770-80a1-d7cdd71792f9)
- Block adding service code if a code for said service already added by the user
![Screenshot 2024-03-07 at 8 37 24 pm](https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/6f9566be-280d-4e0a-9a23-5066095ce7b2)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
