### PR TITLE
hotfix: avoid false positive keyword matches

### DIFF
--- a/src/utils/messageProcessor/index.test.ts
+++ b/src/utils/messageProcessor/index.test.ts
@@ -23,7 +23,7 @@ describe('processMessage', () => {
           fn: km2,
         },
         {
-          matchers: ['nein'],
+          matchers: ['nein', 'sta', 'his', 'thin'],
           fn: noMatch,
         },
       ],

--- a/src/utils/messageProcessor/index.ts
+++ b/src/utils/messageProcessor/index.ts
@@ -1,6 +1,22 @@
 import { Message } from 'discord.js';
 import { logger } from '../logger';
 
+const keywordMatched = (content: string, keyword: string): boolean => {
+  const lowerCaseContent = content.toLowerCase();
+  const matchedIdx = lowerCaseContent.indexOf(keyword);
+
+  if (matchedIdx === -1) {
+    return false;
+  }
+
+  const prevIdx = matchedIdx - 1;
+  const prevIdxValid = prevIdx <= 0 || !lowerCaseContent[prevIdx].match(/[a-z]/);
+  const nextIdx = matchedIdx + keyword.length;
+  const nextIdxValid = nextIdx >= lowerCaseContent.length || !lowerCaseContent[nextIdx].match(/[a-z]/);
+
+  return prevIdxValid && nextIdxValid;
+};
+
 type CommandPromise = Promise<any> | undefined;
 
 type CommandPromises = Array<CommandPromise>;
@@ -14,7 +30,7 @@ type KeywordMatchCommands = Array<KeywordMatchCommand>;
 
 const processKeywordMatch = (message: Message, config: KeywordMatchCommands): CommandPromises => {
   return config.map((conf) => {
-    const hasKeyword = conf.matchers.some((keyword) => message.content.toLowerCase().includes(keyword));
+    const hasKeyword = conf.matchers.some((keyword) => keywordMatched(message.content, keyword));
 
     if (!hasKeyword) {
       return;


### PR DESCRIPTION
To avoid detecting wrong matches due to a keyword being part of another word e.g. `merci` as in `commercial` should have not been matched. 

## Description

This change checks the previous and next characters of the match to make sure it is a whole actual word.


## How Has This Been Tested?
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
