### PR TITLE
give rep bug fix

### DIFF
--- a/src/commands/reputation/giveReputation.test.ts
+++ b/src/commands/reputation/giveReputation.test.ts
@@ -109,7 +109,19 @@ describe('Give rep slash command', () => {
     await giveRepSlashCommand(mockInteraction);
 
     expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('You cannot give rep to yourself');
+    expect(mockInteraction.reply).toHaveBeenCalledWith('You cannot give rep to a bot or yourself');
+  });
+
+  it('should send reject message if user mention a bot', async () => {
+    const mockUser = { id: '1', bot: true } as User;
+    mockInteraction.options.getUser.mockReturnValueOnce(mockUser);
+
+    await giveRepSlashCommand(mockInteraction);
+
+    expect(mockCreateUpdateUser).not.toHaveBeenCalled();
+    expect(mockUpdateRep).not.toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith('You cannot give rep to a bot or yourself');
   });
 
   it('should call reply and add rep if user mention another user', async () => {

--- a/src/commands/reputation/giveReputation.test.ts
+++ b/src/commands/reputation/giveReputation.test.ts
@@ -52,14 +52,16 @@ describe('Thank user in a message', () => {
     expect(mockMessage.reply).not.toHaveBeenCalled();
   });
 
-  it('should send reject message if user mention themself', async () => {
+  it('should do nothing message if user mention themself', async () => {
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '0' } as User);
     mockMessage.mentions.users = mockUsers as typeof mockMessage.mentions.users;
 
     await thankUserInMessage(mockMessage);
 
-    expect(mockMessage.reply).toHaveBeenCalled();
+    expect(mockCreateUpdateUser).not.toHaveBeenCalled();
+    expect(mockUpdateRep).not.toHaveBeenCalled();
+    expect(mockMessage.reply).not.toHaveBeenCalled();
   });
 
   it('should call reply and add rep if user mention another user', async () => {

--- a/src/commands/reputation/giveReputation.ts
+++ b/src/commands/reputation/giveReputation.ts
@@ -18,7 +18,7 @@ export const thankUserInMessage = async (msg: Message) => {
   if (author.bot) return; // return if author is a Discord bot
 
   // Filter out bot users
-  const mentionedUsers = mentions.users.filter((user) => !user.bot);
+  const mentionedUsers = mentions.users.filter((user) => !user.bot && user.id !== author.id);
   if (mentionedUsers.size < 1) return;
 
   const giver = msg.guild?.members.cache.get(author.id);

--- a/src/commands/reputation/giveReputation.ts
+++ b/src/commands/reputation/giveReputation.ts
@@ -53,8 +53,8 @@ export const giveRepSlashCommand = async (interaction: ChatInputCommandInteracti
   const discordUser = interaction.options.getUser('user', true);
 
   const isAuthor = author.id === discordUser.id;
-  if (isAuthor) {
-    await interaction.reply('You cannot give rep to yourself');
+  if (isAuthor || discordUser.bot) {
+    await interaction.reply('You cannot give rep to a bot or yourself');
     return;
   }
 


### PR DESCRIPTION
- **feat: disallow giving rep to bot via slash command**

  ![Screenshot 2024-03-27 at 9 17 26 pm](https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/4152fe3a-9399-44c1-8d2e-21772d6b4ece)

- **feat: thank command will now also filter out the author**
  This will leave out the bug that the bot will send to the channel the starter text
of the thank message.
  ![Screenshot 2024-03-27 at 9 17 08 pm](https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/195796c6-a8c1-40f4-8262-882bf0d0dea0)

