### PR TITLE
feat: Flexible leaderboard

### DIFF
--- a/src/commands/reputation/_helpers.ts
+++ b/src/commands/reputation/_helpers.ts
@@ -1,7 +1,5 @@
 import { getDbClient } from '../../clients';
 
-const MAX_LEADERBOARD = 10;
-
 export const getOrCreateUser = async (userId: string) => {
   const db = getDbClient();
 
@@ -49,19 +47,16 @@ export const updateRep = async ({ fromUserId, toUserId, adjustment }: IUpdateRep
   return updatedUser;
 };
 
-export const getTop10 = async () => {
+export const getRepLeaderboard = async (size: number) => {
   const db = getDbClient();
 
   return db.user.findMany({
-    orderBy: [
-      {
-        reputation: 'desc',
-      },
-    ],
+    where: { reputation: { gt: 0 } },
+    orderBy: [{ reputation: 'desc' }],
     select: {
       id: true,
       reputation: true,
     },
-    take: MAX_LEADERBOARD,
+    take: size,
   });
 };

--- a/src/commands/reputation/leaderboard.test.ts
+++ b/src/commands/reputation/leaderboard.test.ts
@@ -1,11 +1,12 @@
+import { faker } from '@faker-js/faker';
 import { type ChatInputCommandInteraction, Collection, type GuildMember } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep, mockReset } from 'vitest-mock-extended';
-import { getTop10 } from './_helpers';
-import { getLeaderboard as getLeaderboardCommand } from './leaderboard';
+import { getRepLeaderboard } from './_helpers';
+import { DEFAULT_LEADERBOARD, MAX_LEADERBOARD, getLeaderboard as getLeaderboardCommand } from './leaderboard';
 
 vi.mock('./_helpers');
-const mockGetTop10 = vi.mocked(getTop10);
+const mockGetRepLeaderboard = vi.mocked(getRepLeaderboard);
 
 const mockInteraction = mockDeep<ChatInputCommandInteraction<'cached'>>();
 
@@ -14,19 +15,19 @@ describe('leaderboard', () => {
     mockReset(mockInteraction);
   });
 
-  it('Should send reply error if it cannot retrieve the top 10', async () => {
-    mockGetTop10.mockResolvedValueOnce([]);
+  it('Should send reply error if it cannot retrieve the rep leaderboard', async () => {
+    mockGetRepLeaderboard.mockResolvedValueOnce([]);
 
     await getLeaderboardCommand(mockInteraction);
 
-    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith('No one has rep to be on the leaderboard, yet.');
   });
 
   it('Should create a leaderboard entry with nickname if it can be fetched', async () => {
     const userid = '1';
-    mockGetTop10.mockResolvedValueOnce([
+    mockGetRepLeaderboard.mockResolvedValueOnce([
       {
         id: userid,
         reputation: 0,
@@ -38,7 +39,7 @@ describe('leaderboard', () => {
 
     await getLeaderboardCommand(mockInteraction);
 
-    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       `\`\`\`
@@ -50,7 +51,7 @@ describe('leaderboard', () => {
 
   it('Should create a leaderboard entry with displayName if it can be fetched and nickname cannot be fetched', async () => {
     const userid = '1';
-    mockGetTop10.mockResolvedValueOnce([
+    mockGetRepLeaderboard.mockResolvedValueOnce([
       {
         id: userid,
         reputation: 0,
@@ -62,7 +63,7 @@ describe('leaderboard', () => {
 
     await getLeaderboardCommand(mockInteraction);
 
-    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       `\`\`\`
@@ -74,7 +75,7 @@ describe('leaderboard', () => {
 
   it('Should create a leaderboard entry with userid if it cannot retrieve the member', async () => {
     const userid = '1';
-    mockGetTop10.mockResolvedValueOnce([
+    mockGetRepLeaderboard.mockResolvedValueOnce([
       {
         id: userid,
         reputation: 0,
@@ -85,7 +86,7 @@ describe('leaderboard', () => {
 
     await getLeaderboardCommand(mockInteraction);
 
-    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       `\`\`\`
@@ -96,7 +97,7 @@ describe('leaderboard', () => {
   });
 
   it('Should send reply with leaderboard with more than 1 record in correct order', async () => {
-    mockGetTop10.mockResolvedValueOnce([
+    mockGetRepLeaderboard.mockResolvedValueOnce([
       {
         id: '3',
         reputation: 3,
@@ -117,7 +118,7 @@ describe('leaderboard', () => {
 
     await getLeaderboardCommand(mockInteraction);
 
-    expect(mockGetTop10).toHaveBeenCalledOnce();
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledOnce();
     expect(mockInteraction.reply).toHaveBeenCalledWith(
       `\`\`\`
@@ -125,6 +126,85 @@ describe('leaderboard', () => {
  1        3   3
  2     sam2   2
  3      sam   1
+\`\`\``
+    );
+  });
+
+  it(`should reject if it goes over MAX of ${MAX_LEADERBOARD}`, () => {
+    mockInteraction.options.getNumber.mockReturnValueOnce(MAX_LEADERBOARD + 1);
+
+    getLeaderboardCommand(mockInteraction);
+
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(`The size is too big. Max is ${MAX_LEADERBOARD}`);
+  });
+
+  it('Should send reply with leaderboard with provided number', async () => {
+    mockInteraction.options.getNumber.mockReturnValueOnce(3);
+    mockGetRepLeaderboard.mockResolvedValueOnce([
+      {
+        id: '3',
+        reputation: 3,
+      },
+      {
+        id: '2',
+        reputation: 2,
+      },
+      {
+        id: '1',
+        reputation: 1,
+      },
+    ]);
+    const mockMembers = new Collection<string, GuildMember>();
+    mockMembers.set('1', { nickname: 'sam' } as GuildMember);
+    mockMembers.set('2', { nickname: 'sam2' } as GuildMember);
+    mockMembers.set('3', { nickname: 'sam3' } as GuildMember);
+    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+
+    await getLeaderboardCommand(mockInteraction);
+
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      `\`\`\`
+ # username rep
+ 1     sam3   3
+ 2     sam2   2
+ 3      sam   1
+\`\`\``
+    );
+  });
+
+  it(`should send reply leaderboard with a default of ${DEFAULT_LEADERBOARD}`, async () => {
+    const mockRepLeaderboard: Awaited<ReturnType<typeof getRepLeaderboard>> = [];
+    const mockMembers = new Collection<string, GuildMember>();
+    for (let i = DEFAULT_LEADERBOARD; i >= 1; i--) {
+      mockMembers.set(`${i}`, { nickname: `sam${i}` } as GuildMember);
+      mockRepLeaderboard.push({
+        id: `${i}`,
+        reputation: i,
+      });
+    }
+    mockGetRepLeaderboard.mockResolvedValueOnce(mockRepLeaderboard);
+    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+
+    await getLeaderboardCommand(mockInteraction);
+
+    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      `\`\`\`
+ # username rep
+ 1    sam10  10
+ 2     sam9   9
+ 3     sam8   8
+ 4     sam7   7
+ 5     sam6   6
+ 6     sam5   5
+ 7     sam4   4
+ 8     sam3   3
+ 9     sam2   2
+10     sam1   1
 \`\`\``
     );
   });

--- a/src/utils/messageProcessor/index.ts
+++ b/src/utils/messageProcessor/index.ts
@@ -6,13 +6,13 @@ const keywordMatched = (sentence: string, keyword: string): boolean => {
   return regex.test(sentence);
 };
 
-type CommandPromise = Promise<undefined> | undefined;
+type CommandPromise = Promise<void> | void;
 
 type CommandPromises = Array<CommandPromise>;
 
 interface KeywordMatchCommand {
   matchers: Array<string>;
-  fn: (message: Message) => Promise<undefined>;
+  fn: (message: Message) => Promise<void>;
 }
 
 type KeywordMatchCommands = Array<KeywordMatchCommand>;
@@ -33,7 +33,7 @@ export interface CommandConfig {
   keywordMatchCommands: KeywordMatchCommands;
 }
 
-export const processMessage = async (message: Message, config: CommandConfig): Promise<undefined> => {
+export const processMessage = async (message: Message, config: CommandConfig): Promise<void> => {
   const keywordPromises = processKeywordMatch(message, config.keywordMatchCommands);
 
   try {


### PR DESCRIPTION
## Description
- Rename getTop10 function into getRepLeaderboard
- Change the rep leaderboard command to take an optional size and having a max number of users that it should query

## Related Issue
Resolves #220 

## How Has This Been Tested?
- Verified via unit test
- Verified via integration test with bot testing server using the following method:
  - Write a script to insert 100 users into a test database
  - Hook up bot to Bot Testing server and the test database
  - Run rep leaderboard commands:
    - with size 1
    - with size default
    - with size max
    - with size > MAX

## Screenshots (if appropriate):

- <img width="328" alt="Screenshot 2024-04-02 at 9 28 41 pm" src="https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/e09f7863-12d1-4fe8-935b-ba8e84e90d13">
- <img width="325" alt="Screenshot 2024-04-02 at 9 28 44 pm" src="https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/baceb94c-4b38-487d-b990-be2cea7826be">
- <img width="336" alt="Screenshot 2024-04-02 at 9 28 47 pm" src="https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/678bc67f-e3e6-4a56-b9f8-ca1cbb86fe24">
- <img width="311" alt="Screenshot 2024-04-02 at 9 28 53 pm" src="https://github.com/viet-aus-it/vait-discord-bot/assets/4188758/902dd6b2-0da2-47be-87ff-bd691659427c">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
