### PR TITLE
feat: AOC Leaderboard commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "msw": "^2.6.8",
     "pino-pretty": "^13.0.0",
     "prisma": "^6.0.1",
+    "prisma-json-types-generator": "^3.2.2",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       prisma:
         specifier: ^6.0.1
         version: 6.0.1
+      prisma-json-types-generator:
+        specifier: ^3.2.2
+        version: 3.2.2(prisma@6.0.1)(typescript@5.7.2)
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(postcss@8.4.33)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.6.1)
@@ -771,6 +774,9 @@ packages:
       prisma:
         optional: true
 
+  '@prisma/debug@6.0.0':
+    resolution: {integrity: sha512-eUjoNThlDXdyJ1iQ2d7U6aTVwm59EwvODb5zFVNJEokNoSiQmiYWNzZIwZyDmZ+j51j42/0iTaHIJ4/aZPKFRg==}
+
   '@prisma/debug@6.0.1':
     resolution: {integrity: sha512-jQylgSOf7ibTVxqBacnAlVGvek6fQxJIYCQOeX2KexsfypNzXjJQSS2o5s+Mjj2Np93iSOQUaw6TvPj8syhG4w==}
 
@@ -782,6 +788,9 @@ packages:
 
   '@prisma/fetch-engine@6.0.1':
     resolution: {integrity: sha512-T36bWFVGeGYYSyYOj9d+O9G3sBC+pAyMC+jc45iSL63/Haq1GrYjQPgPMxrEj9m739taXrupoysRedQ+VyvM/Q==}
+
+  '@prisma/generator-helper@6.0.0':
+    resolution: {integrity: sha512-5DkG7hspZo6U4OtqI2W0JcgtY37sr7HgT8Q0W/sjL4VoV4px6ivzK6Eif5bKM7q+S4yFUHtjUt/3s69ErfLn7A==}
 
   '@prisma/get-platform@6.0.1':
     resolution: {integrity: sha512-zspC9vlxAqx4E6epMPMLLBMED2VD8axDe8sPnquZ8GOsn6tiacWK0oxrGK4UAHYzYUVuMVUApJbdXB2dFpLhvg==}
@@ -1801,6 +1810,14 @@ packages:
     resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prisma-json-types-generator@3.2.2:
+    resolution: {integrity: sha512-kvEbJPIP5gxk65KmLs0nAvY+CxpqVMWb4OsEvXlyXZmp2IGfi5f52BUV7ezTYQNjRPZyR4QlayWJXffoqVVAfA==}
+    engines: {node: '>=14.0'}
+    hasBin: true
+    peerDependencies:
+      prisma: ^5 || ^6
+      typescript: ^5.6.2
+
   prisma@6.0.1:
     resolution: {integrity: sha512-CaMNFHkf+DDq8zq3X/JJsQ4Koy7dyWwwtOKibkT/Am9j/tDxcfbg7+lB1Dzhx18G/+RQCMgjPYB61bhRqteNBQ==}
     engines: {node: '>=18.18'}
@@ -2768,6 +2785,8 @@ snapshots:
     optionalDependencies:
       prisma: 6.0.1
 
+  '@prisma/debug@6.0.0': {}
+
   '@prisma/debug@6.0.1': {}
 
   '@prisma/engines-version@5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e': {}
@@ -2784,6 +2803,10 @@ snapshots:
       '@prisma/debug': 6.0.1
       '@prisma/engines-version': 5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e
       '@prisma/get-platform': 6.0.1
+
+  '@prisma/generator-helper@6.0.0':
+    dependencies:
+      '@prisma/debug': 6.0.0
 
   '@prisma/get-platform@6.0.1':
     dependencies:
@@ -3801,6 +3824,13 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.2.0
+
+  prisma-json-types-generator@3.2.2(prisma@6.0.1)(typescript@5.7.2):
+    dependencies:
+      '@prisma/generator-helper': 6.0.0
+      prisma: 6.0.1
+      tslib: 2.8.1
+      typescript: 5.7.2
 
   prisma@6.0.1:
     dependencies:

--- a/prisma/migrations/20241214153245_aoc_models_and_settings/migration.sql
+++ b/prisma/migrations/20241214153245_aoc_models_and_settings/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE "ServerChannelsSettings" ADD COLUMN     "aocKey" TEXT,
+ADD COLUMN     "aocLeaderboardId" TEXT;
+
+-- CreateTable
+CREATE TABLE "AocLeaderboard" (
+    "guildId" TEXT NOT NULL,
+    "result" JSONB NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AocLeaderboard_guildId_key" ON "AocLeaderboard"("guildId");
+
+-- CreateIndex
+CREATE INDEX "AocLeaderboard_guildId_idx" ON "AocLeaderboard"("guildId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,10 @@ generator client {
   previewFeatures = ["relationJoins", "omitApi"]
 }
 
+generator json {
+  provider = "prisma-json-types-generator"
+}
+
 model User {
   id String @id
 
@@ -61,6 +65,16 @@ model ServerChannelsSettings {
   autobumpThreads  String[] @default([])
   aocKey           String?
   aocLeaderboardId String?
+
+  @@index(guildId)
+}
+
+model AocLeaderboard {
+  guildId String @unique
+
+  /// [AocLeaderboardData]
+  result    Json
+  updatedAt DateTime @default(now())
 
   @@index(guildId)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 generator client {
   provider        = "prisma-client-js"
   binaryTargets   = ["native", "debian-openssl-1.1.x"]
-  previewFeatures = ["relationJoins"]
+  previewFeatures = ["relationJoins", "omitApi"]
 }
 
 model User {
@@ -56,9 +56,11 @@ model Reminder {
 }
 
 model ServerChannelsSettings {
-  guildId         String   @unique
-  reminderChannel String?  @unique
-  autobumpThreads String[] @default([])
+  guildId          String   @unique
+  reminderChannel  String?  @unique
+  autobumpThreads  String[] @default([])
+  aocKey           String?
+  aocLeaderboardId String?
 
   @@index(guildId)
 }

--- a/src/clients/prisma.ts
+++ b/src/clients/prisma.ts
@@ -1,4 +1,11 @@
 import { PrismaClient } from '@prisma/client';
+import type { AocLeaderboard } from '../slash-commands/aoc-leaderboard/schema';
+
+declare global {
+  namespace PrismaJson {
+    type AocLeaderboardData = AocLeaderboard;
+  }
+}
 
 const prisma = new PrismaClient({
   omit: {

--- a/src/clients/prisma.ts
+++ b/src/clients/prisma.ts
@@ -1,5 +1,11 @@
 import { PrismaClient } from '@prisma/client';
 
-const prisma: PrismaClient = new PrismaClient();
+const prisma = new PrismaClient({
+  omit: {
+    serverChannelsSettings: {
+      aocKey: true,
+    },
+  },
+});
 
 export const getDbClient = () => prisma;

--- a/src/slash-commands/aoc-leaderboard/client.ts
+++ b/src/slash-commands/aoc-leaderboard/client.ts
@@ -1,0 +1,24 @@
+import wretch from 'wretch';
+import { logger } from '../../utils/logger';
+import { AocLeaderboard } from './schema';
+
+function getAocClient(aocKey: string) {
+  return wretch('https://adventofcode.com')
+    .options({ credentials: 'same-origin' })
+    .headers({
+      Cookie: `session=${aocKey}`,
+      'User-Agent': 'https://github.com/viet-aus-it/discord-bot by admin@vietausit.com',
+    });
+}
+
+export async function fetchLeaderboard(aocKey: string, leaderboardId: string, year: number) {
+  const result = await getAocClient(aocKey).url(`/${year}/leaderboard/private/view/${leaderboardId}.json`).get().json();
+
+  const parsedResult = AocLeaderboard.safeParse(result);
+  if (!parsedResult.success) {
+    logger.error('ERROR: Cannot get leaderboard format.', parsedResult.error);
+    throw new Error(parsedResult.error.stack);
+  }
+
+  return parsedResult.data;
+}

--- a/src/slash-commands/aoc-leaderboard/index.test.ts
+++ b/src/slash-commands/aoc-leaderboard/index.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { subHours } from 'date-fns';
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,6 +14,9 @@ const mockGetAocSettings = vi.mocked(getAocSettings);
 const mockFetchAndSaveLeaderboard = vi.mocked(fetchAndSaveLeaderboard);
 const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const parsedMockData = AocLeaderboard.parse(mockAocData);
+const mockKey = faker.string.alphanumeric({ length: 127 });
+const mockLeaderboardId = faker.string.alphanumeric();
+const mockGuildId = faker.string.numeric();
 
 const mockSystemTime = new Date(2024, 11, 25, 16, 0, 0); // 25/12/2024 16:00:00
 const oneHourEarlier = subHours(mockSystemTime, 1); // 25/12/2024 15:00:00
@@ -114,9 +118,9 @@ Last updated at: 25/12/2024 16:00
         updatedAt: oneHourEarlier,
       });
       mockGetAocSettings.mockResolvedValueOnce({
-        guildId: '12345',
-        aocKey: '12345',
-        aocLeaderboardId: '12345',
+        guildId: mockGuildId,
+        aocKey: mockKey,
+        aocLeaderboardId: mockLeaderboardId,
       });
       mockFetchAndSaveLeaderboard.mockRejectedValueOnce(new Error('Synthetic error fetch and save'));
 
@@ -133,9 +137,9 @@ Last updated at: 25/12/2024 16:00
         updatedAt: oneHourEarlier,
       });
       mockGetAocSettings.mockResolvedValueOnce({
-        guildId: '12345',
-        aocKey: '12345',
-        aocLeaderboardId: '12345',
+        guildId: mockGuildId,
+        aocKey: mockKey,
+        aocLeaderboardId: mockLeaderboardId,
       });
       mockFetchAndSaveLeaderboard.mockResolvedValueOnce({
         result: parsedMockData,

--- a/src/slash-commands/aoc-leaderboard/index.test.ts
+++ b/src/slash-commands/aoc-leaderboard/index.test.ts
@@ -1,0 +1,159 @@
+import { subHours } from 'date-fns';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { execute, formatLeaderboard, getAocYear } from '.';
+import mockAocData from './sample/aoc-data.json';
+import { AocLeaderboard } from './schema';
+import { fetchAndSaveLeaderboard, getAocSettings, getSavedLeaderboard } from './utils';
+
+vi.mock('./utils');
+const mockGetSavedLeaderboard = vi.mocked(getSavedLeaderboard);
+const mockGetAocSettings = vi.mocked(getAocSettings);
+const mockFetchAndSaveLeaderboard = vi.mocked(fetchAndSaveLeaderboard);
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
+const parsedMockData = AocLeaderboard.parse(mockAocData);
+
+const mockSystemTime = new Date(2024, 11, 25, 16, 0, 0); // 25/12/2024 16:00:00
+const oneHourEarlier = subHours(mockSystemTime, 1); // 25/12/2024 15:00:00
+
+describe('Get AOC Leaderboard test', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockSystemTime);
+    mockReset(mockInteraction);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('Get AOC Year', () => {
+    it('Should return this year leaderboard if it is December', () => {
+      const date = new Date(2024, 11, 1);
+      vi.setSystemTime(date);
+      const year = getAocYear();
+      expect(year).toEqual(2024);
+    });
+
+    it('Should return previous year leaderboard if it is not December', () => {
+      const date = new Date(2024, 1, 1);
+      vi.setSystemTime(date);
+      const year = getAocYear();
+      expect(year).toEqual(2023);
+    });
+  });
+
+  describe('Format leaderboard', () => {
+    it('Should match the leaderboard format', () => {
+      const leaderboardMessage = formatLeaderboard({
+        result: parsedMockData,
+        updatedAt: mockSystemTime,
+      });
+      expect(leaderboardMessage).toEqual(`\`\`\`
+ #               name score
+ 1 (anonymous user 4) 474
+ 2              user2 361
+ 3              user3 353
+ 4              user1   0
+
+
+Last updated at: 25/12/2024 16:00
+\`\`\``);
+    });
+  });
+
+  describe('Command tests', () => {
+    it('Should reply with saved leaderboard if it can get one', async () => {
+      mockGetSavedLeaderboard.mockResolvedValueOnce({
+        result: parsedMockData,
+        updatedAt: mockSystemTime,
+      });
+
+      await execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(`\`\`\`
+ #               name score
+ 1 (anonymous user 4) 474
+ 2              user2 361
+ 3              user3 353
+ 4              user1   0
+
+
+Last updated at: 25/12/2024 16:00
+\`\`\``);
+    });
+
+    it('Should reply with error if it errors out while finding aoc settings', async () => {
+      mockGetSavedLeaderboard.mockResolvedValueOnce({
+        result: parsedMockData,
+        updatedAt: oneHourEarlier,
+      });
+      mockGetAocSettings.mockRejectedValueOnce(new Error('Synthetic Error Get Settings'));
+
+      await execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith('ERROR: Error: Synthetic Error Get Settings');
+    });
+
+    it('Should reply with error if server is not configured', async () => {
+      mockGetSavedLeaderboard.mockResolvedValueOnce({
+        result: parsedMockData,
+        updatedAt: oneHourEarlier,
+      });
+      mockGetAocSettings.mockResolvedValueOnce(null);
+
+      await execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith('ERROR: Server is not configured to get AOC results! Missing Key and/or Leaderboard ID.');
+    });
+
+    it('Should reply with error if there is one during fetching and saving', async () => {
+      mockGetSavedLeaderboard.mockResolvedValueOnce({
+        result: parsedMockData,
+        updatedAt: oneHourEarlier,
+      });
+      mockGetAocSettings.mockResolvedValueOnce({
+        guildId: '12345',
+        aocKey: '12345',
+        aocLeaderboardId: '12345',
+      });
+      mockFetchAndSaveLeaderboard.mockRejectedValueOnce(new Error('Synthetic error fetch and save'));
+
+      await execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        'ERROR: Error fetching and/or saving new leaderboard result: Error: Synthetic error fetch and save'
+      );
+    });
+
+    it('Should reply with newly fetched leaderboard after fetching and saving', async () => {
+      mockGetSavedLeaderboard.mockResolvedValueOnce({
+        result: parsedMockData,
+        updatedAt: oneHourEarlier,
+      });
+      mockGetAocSettings.mockResolvedValueOnce({
+        guildId: '12345',
+        aocKey: '12345',
+        aocLeaderboardId: '12345',
+      });
+      mockFetchAndSaveLeaderboard.mockResolvedValueOnce({
+        result: parsedMockData,
+        updatedAt: mockSystemTime,
+      });
+
+      await execute(mockInteraction);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(`\`\`\`
+ #               name score
+ 1 (anonymous user 4) 474
+ 2              user2 361
+ 3              user3 353
+ 4              user1   0
+
+
+Last updated at: 25/12/2024 16:00
+\`\`\``);
+    });
+  });
+});

--- a/src/slash-commands/aoc-leaderboard/index.ts
+++ b/src/slash-commands/aoc-leaderboard/index.ts
@@ -1,0 +1,105 @@
+import type { AocLeaderboard } from '@prisma/client';
+import { differenceInMinutes } from 'date-fns';
+import { format } from 'date-fns';
+import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { Result } from 'oxide.ts';
+import { DAY_MONTH_YEAR_HOUR_MINUTE_FORMAT } from '../../utils/date';
+import { logger } from '../../utils/logger';
+import type { SlashCommand } from '../builder';
+import { fetchAndSaveLeaderboard, getAocSettings, getSavedLeaderboard } from './utils';
+
+export const DEFAULT_LEADERBOARD = 10;
+
+const data = new SlashCommandBuilder()
+  .setName('aoc-leaderboard')
+  .setDescription("Fetch advent of code leaderboard. Will get current year, or the previous one if it isn't Dec yet.");
+
+export function getAocYear(): number {
+  const DECEMBER = 11;
+  const date = new Date();
+  const month = date.getMonth();
+  const year = date.getFullYear();
+  if (month < DECEMBER) {
+    return year - 1;
+  }
+
+  return year;
+}
+
+export function formatLeaderboard({ result: leaderboard, updatedAt }: Pick<AocLeaderboard, 'result' | 'updatedAt'>): string {
+  const memberScores = Object.values(leaderboard.members)
+    .sort((prev, next) => next.local_score - prev.local_score)
+    .slice(0, DEFAULT_LEADERBOARD);
+
+  const nameLength = Math.max(...memberScores.map((m) => m.name.length));
+  const scoreLength = Math.max(...memberScores.map((m) => m.local_score.toString().length));
+  const titleString = `${'#'.padStart(2, ' ')} ${'name'.padStart(nameLength, ' ')} ${'score'.padStart(scoreLength, ' ')}\n`;
+
+  const board = memberScores.reduce((accum, { name, local_score: score }, currentIndex) => {
+    const position = (currentIndex + 1).toString().padStart(2, ' ');
+    const paddedName = name.padStart(nameLength, ' ');
+    const paddedScore = score.toString().padStart(scoreLength, ' ');
+    return `${accum}${position} ${paddedName} ${paddedScore}\n`;
+  }, titleString);
+
+  const timestamp = format(updatedAt, DAY_MONTH_YEAR_HOUR_MINUTE_FORMAT);
+
+  return `\`\`\`
+${board}
+
+Last updated at: ${timestamp}
+\`\`\``;
+}
+
+export const execute = async (interaction: ChatInputCommandInteraction) => {
+  await interaction.deferReply();
+
+  const guildId = interaction.guildId!;
+
+  const getSavedleaderboardOp = await Result.safe(getSavedLeaderboard(guildId));
+  const savedResult = getSavedleaderboardOp.unwrap();
+  if (!getSavedleaderboardOp.isErr() && savedResult && differenceInMinutes(new Date(), savedResult.updatedAt) <= 15) {
+    logger.info('[get-aoc-leaderboard]: Returning saved leaderboard data');
+    const formattedLeaderboard = formatLeaderboard(savedResult);
+    await interaction.editReply(formattedLeaderboard);
+    return;
+  }
+
+  logger.info('[get-aoc-leaderboard]: Cannot find saved leaderboard, fetching new results');
+
+  const settingsOp = await Result.safe(getAocSettings(guildId));
+  if (settingsOp.isErr()) {
+    const errorMessage = settingsOp.unwrapErr();
+    logger.error(`[get-aoc-leaderboard]: Error getting AOC settings: ${errorMessage}`);
+    await interaction.editReply(`ERROR: ${errorMessage}`);
+    return;
+  }
+
+  const settings = settingsOp.unwrap();
+  if (!settings || !settings.aocKey || !settings.aocLeaderboardId) {
+    const errorMessage = 'Server is not configured to get AOC results! Missing Key and/or Leaderboard ID.';
+    logger.error(`[get-aoc-leaderboard]: ${errorMessage}`);
+    await interaction.editReply(`ERROR: ${errorMessage}`);
+    return;
+  }
+
+  const year = getAocYear();
+  const fetchAndSaveOp = await Result.safe(fetchAndSaveLeaderboard(year, settings));
+  if (fetchAndSaveOp.isErr()) {
+    const errorMessage = `Error fetching and/or saving new leaderboard result: ${fetchAndSaveOp.unwrapErr()}`;
+    logger.error(`[get-aoc-leaderboard]: ${errorMessage}`);
+    await interaction.editReply(`ERROR: ${errorMessage}`);
+    return;
+  }
+
+  const leaderboardData = fetchAndSaveOp.unwrap();
+  const message = formatLeaderboard(leaderboardData);
+  await interaction.editReply(message);
+};
+
+const command: SlashCommand = {
+  data,
+  execute,
+};
+
+export default command;

--- a/src/slash-commands/aoc-leaderboard/sample/aoc-data.json
+++ b/src/slash-commands/aoc-leaderboard/sample/aoc-data.json
@@ -1,0 +1,176 @@
+{
+  "event": "2024",
+  "day1_ts": 1733029200,
+  "owner_id": 4,
+  "members": {
+    "1": {
+      "name": "user1",
+      "stars": 0,
+      "id": 1,
+      "local_score": 0,
+      "last_star_ts": 0,
+      "global_score": 0,
+      "completion_day_level": {}
+    },
+    "2": {
+      "local_score": 361,
+      "name": "user2",
+      "id": 2,
+      "stars": 21,
+      "last_star_ts": 1733894725,
+      "global_score": 0,
+      "completion_day_level": {
+        "7": {
+          "2": { "get_star_ts": 1733568536, "star_index": 1512936 },
+          "1": { "star_index": 1472641, "get_star_ts": 1733551195 }
+        },
+        "5": {
+          "2": { "get_star_ts": 1733445833, "star_index": 1255655 },
+          "1": { "star_index": 1254794, "get_star_ts": 1733445061 }
+        },
+        "6": {
+          "2": { "get_star_ts": 1733484187, "star_index": 1338165 },
+          "1": { "star_index": 1283528, "get_star_ts": 1733463996 }
+        },
+        "11": { "1": { "star_index": 2119477, "get_star_ts": 1733894725 } },
+        "3": {
+          "2": { "get_star_ts": 1733268459, "star_index": 786907 },
+          "1": { "get_star_ts": 1733203594, "star_index": 539606 }
+        },
+        "4": {
+          "2": { "get_star_ts": 1733290653, "star_index": 826786 },
+          "1": { "get_star_ts": 1733289860, "star_index": 821554 }
+        },
+        "9": {
+          "2": { "get_star_ts": 1733727845, "star_index": 1818699 },
+          "1": { "star_index": 1810353, "get_star_ts": 1733724337 }
+        },
+        "10": {
+          "1": { "get_star_ts": 1733877257, "star_index": 2099650 },
+          "2": { "star_index": 2099680, "get_star_ts": 1733877298 }
+        },
+        "1": {
+          "2": { "get_star_ts": 1733046375, "star_index": 50739 },
+          "1": { "get_star_ts": 1733046007, "star_index": 49631 }
+        },
+        "2": {
+          "2": { "get_star_ts": 1733121725, "star_index": 254602 },
+          "1": { "star_index": 249006, "get_star_ts": 1733120270 }
+        },
+        "8": {
+          "2": { "star_index": 1686894, "get_star_ts": 1733656454 },
+          "1": { "get_star_ts": 1733655334, "star_index": 1684027 }
+        }
+      }
+    },
+    "3": {
+      "last_star_ts": 1733987841,
+      "completion_day_level": {
+        "8": {
+          "1": { "get_star_ts": 1733658460, "star_index": 1691853 },
+          "2": { "get_star_ts": 1733659480, "star_index": 1694317 }
+        },
+        "1": {
+          "2": { "star_index": 32603, "get_star_ts": 1733039703 },
+          "1": { "get_star_ts": 1733039564, "star_index": 32241 }
+        },
+        "2": {
+          "2": { "star_index": 344259, "get_star_ts": 1733143455 },
+          "1": { "star_index": 299909, "get_star_ts": 1733132313 }
+        },
+        "12": { "1": { "star_index": 2274276, "get_star_ts": 1733987841 } },
+        "10": {
+          "1": { "star_index": 2105335, "get_star_ts": 1733885261 },
+          "2": { "star_index": 2106144, "get_star_ts": 1733886485 }
+        },
+        "9": { "1": { "get_star_ts": 1733740657, "star_index": 1846156 } },
+        "4": {
+          "2": { "star_index": 889272, "get_star_ts": 1733307427 },
+          "1": { "get_star_ts": 1733306753, "star_index": 886874 }
+        },
+        "3": {
+          "2": { "get_star_ts": 1733253510, "star_index": 739389 },
+          "1": { "star_index": 736904, "get_star_ts": 1733252762 }
+        },
+        "11": {
+          "2": { "star_index": 2131764, "get_star_ts": 1733898917 },
+          "1": { "star_index": 2131620, "get_star_ts": 1733898853 }
+        },
+        "6": {
+          "1": { "star_index": 1316149, "get_star_ts": 1733475769 },
+          "2": { "star_index": 1422590, "get_star_ts": 1733519751 }
+        },
+        "5": {
+          "2": { "star_index": 1103621, "get_star_ts": 1733387120 },
+          "1": { "star_index": 1102675, "get_star_ts": 1733386820 }
+        },
+        "7": {
+          "2": { "star_index": 1511599, "get_star_ts": 1733568036 },
+          "1": { "star_index": 1506389, "get_star_ts": 1733565987 }
+        }
+      },
+      "global_score": 0,
+      "name": "user3",
+      "id": 3,
+      "stars": 22,
+      "local_score": 353
+    },
+    "4": {
+      "completion_day_level": {
+        "11": {
+          "2": { "star_index": 2130521, "get_star_ts": 1733898370 },
+          "1": { "get_star_ts": 1733894892, "star_index": 2120299 }
+        },
+        "3": {
+          "1": { "star_index": 530548, "get_star_ts": 1733202739 },
+          "2": { "star_index": 539204, "get_star_ts": 1733203549 }
+        },
+        "4": {
+          "2": { "get_star_ts": 1733290034, "star_index": 822789 },
+          "1": { "get_star_ts": 1733289723, "star_index": 820605 }
+        },
+        "5": {
+          "2": { "star_index": 1073268, "get_star_ts": 1733377953 },
+          "1": { "star_index": 1062574, "get_star_ts": 1733376173 }
+        },
+        "6": {
+          "1": { "star_index": 1272214, "get_star_ts": 1733461855 },
+          "2": { "star_index": 1290926, "get_star_ts": 1733466220 }
+        },
+        "7": {
+          "1": { "star_index": 1457480, "get_star_ts": 1733548093 },
+          "2": { "get_star_ts": 1733549054, "star_index": 1463797 }
+        },
+        "2": {
+          "2": { "star_index": 223024, "get_star_ts": 1733116187 },
+          "1": { "get_star_ts": 1733115925, "star_index": 220330 }
+        },
+        "1": {
+          "2": { "get_star_ts": 1733029456, "star_index": 1263 },
+          "1": { "get_star_ts": 1733029364, "star_index": 0 }
+        },
+        "8": {
+          "2": { "get_star_ts": 1733635137, "star_index": 1633972 },
+          "1": { "star_index": 1632691, "get_star_ts": 1733634907 }
+        },
+        "12": {
+          "2": { "star_index": 2281284, "get_star_ts": 1733992330 },
+          "1": { "star_index": 2257118, "get_star_ts": 1733980246 }
+        },
+        "10": {
+          "1": { "get_star_ts": 1733807294, "star_index": 1958420 },
+          "2": { "get_star_ts": 1733808865, "star_index": 1967914 }
+        },
+        "9": {
+          "1": { "get_star_ts": 1733724097, "star_index": 1809632 },
+          "2": { "star_index": 1817110, "get_star_ts": 1733727086 }
+        }
+      },
+      "global_score": 0,
+      "last_star_ts": 1733992330,
+      "local_score": 474,
+      "stars": 4,
+      "id": 4
+    }
+  }
+}

--- a/src/slash-commands/aoc-leaderboard/schema.ts
+++ b/src/slash-commands/aoc-leaderboard/schema.ts
@@ -27,7 +27,6 @@ export const AocLeaderboard = z
   .passthrough()
   .transform((board) => {
     const sortedMembers = Object.values(board.members)
-      .filter((member) => member.local_score === 0)
       .toSorted((prev, next) => next.local_score - prev.local_score)
       .reduce(
         (accum, member) => {

--- a/src/slash-commands/aoc-leaderboard/schema.ts
+++ b/src/slash-commands/aoc-leaderboard/schema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const Member = z
+  .object({
+    id: z.coerce.number(),
+    name: z.string().nullish(),
+    local_score: z.number(),
+  })
+  .passthrough()
+  .transform((m): typeof m & { name: string } => {
+    if (!m.name) {
+      return {
+        ...m,
+        name: `(anonymous user ${m.id})`,
+      };
+    }
+
+    return m as typeof m & { name: string };
+  });
+export type Member = z.infer<typeof Member>;
+
+export const AocLeaderboard = z
+  .object({
+    event: z.number(),
+    members: z.record(z.string(), Member),
+  })
+  .passthrough()
+  .transform((board) => {
+    const sortedMembers = Object.values(board.members)
+      .filter((member) => member.local_score === 0)
+      .toSorted((prev, next) => next.local_score - prev.local_score)
+      .reduce(
+        (accum, member) => {
+          accum[member.id] = member;
+          return accum;
+        },
+        {} as Record<string, Member>
+      );
+    return {
+      ...board,
+      members: sortedMembers,
+    };
+  });
+export type AocLeaderboard = z.infer<typeof AocLeaderboard>;

--- a/src/slash-commands/aoc-leaderboard/schema.ts
+++ b/src/slash-commands/aoc-leaderboard/schema.ts
@@ -21,7 +21,7 @@ export type Member = z.infer<typeof Member>;
 
 export const AocLeaderboard = z
   .object({
-    event: z.number(),
+    event: z.coerce.number(),
     members: z.record(z.string(), Member),
   })
   .passthrough()

--- a/src/slash-commands/aoc-leaderboard/utils.ts
+++ b/src/slash-commands/aoc-leaderboard/utils.ts
@@ -1,0 +1,56 @@
+import type { ServerChannelsSettings } from '@prisma/client';
+import { getDbClient } from '../../clients';
+import { logger } from '../../utils/logger';
+import { fetchLeaderboard } from './client';
+
+export const getAocSettings = async (guildId: string) => {
+  const db = getDbClient();
+  return db.serverChannelsSettings.findFirst({
+    where: { guildId },
+    select: {
+      guildId: true,
+      aocKey: true,
+      aocLeaderboardId: true,
+    },
+  });
+};
+
+type AocSettings = Pick<ServerChannelsSettings, 'aocKey' | 'aocLeaderboardId' | 'guildId'>;
+export const fetchAndSaveLeaderboard = async (year: number, { aocKey, aocLeaderboardId, guildId }: AocSettings) => {
+  if (!aocKey || !aocLeaderboardId) {
+    const errorMessage = 'Cannot fetch leaderboard without key and leaderboard id';
+    logger.error(`[fetch-and-save-leaderboard]: ${errorMessage}!`);
+    throw new Error(errorMessage);
+  }
+  const aocLeaderboardResponse = await fetchLeaderboard(aocKey, aocLeaderboardId, year);
+
+  const db = getDbClient();
+  const savedResult = await db.aocLeaderboard.upsert({
+    where: { guildId },
+    update: {
+      updatedAt: new Date(),
+      result: aocLeaderboardResponse,
+    },
+    create: {
+      guildId,
+      result: aocLeaderboardResponse,
+    },
+    select: {
+      result: true,
+      updatedAt: true,
+    },
+  });
+
+  return savedResult;
+};
+
+export const getSavedLeaderboard = async (guildId: string) => {
+  const db = getDbClient();
+  return db.aocLeaderboard.findFirst({
+    where: { guildId },
+    select: {
+      result: true,
+      updatedAt: true,
+    },
+  });
+};

--- a/src/slash-commands/index.ts
+++ b/src/slash-commands/index.ts
@@ -1,5 +1,6 @@
 import ask8ball from './8ball';
 import allCap from './all-cap';
+import getAocLeaderboard from './aoc-leaderboard';
 import autobumpThread from './autobump-threads';
 import type { SlashCommand } from './builder';
 import cowsayCommand from './cowsay';
@@ -33,4 +34,5 @@ export const commands: SlashCommand[] = [
   reminder,
   serverSettings,
   removeUserByRole,
+  getAocLeaderboard,
 ];

--- a/src/slash-commands/server-settings/index.ts
+++ b/src/slash-commands/server-settings/index.ts
@@ -1,11 +1,16 @@
 import { type GuildMember, SlashCommandBuilder } from 'discord.js';
 import { isAdmin, isModerator } from '../../utils/permission';
 import type { SlashCommand, SlashCommandHandler } from '../builder';
+import setAocSettings from './set-aoc-settings';
 import setReminderChannel from './set-reminder-channel';
 
-const data = new SlashCommandBuilder().setName('server-settings').setDescription('ADMIN ONLY COMMAND. Server Settings.').addSubcommand(setReminderChannel.data);
+const data = new SlashCommandBuilder()
+  .setName('server-settings')
+  .setDescription('ADMIN ONLY COMMAND. Server Settings.')
+  .addSubcommand(setReminderChannel.data)
+  .addSubcommand(setAocSettings.data);
 
-const subcommands = [setReminderChannel];
+const subcommands = [setReminderChannel, setAocSettings];
 
 const execute: SlashCommandHandler = async (interaction) => {
   const member = interaction.member as GuildMember;

--- a/src/slash-commands/server-settings/set-aoc-settings.test.ts
+++ b/src/slash-commands/server-settings/set-aoc-settings.test.ts
@@ -1,0 +1,71 @@
+import { faker } from '@faker-js/faker';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { execute } from './set-aoc-settings';
+import { setAocSettings } from './utils';
+
+vi.mock('./utils');
+const mockSetAocSettings = vi.mocked(setAocSettings);
+const mockChatInputInteraction = mockDeep<ChatInputCommandInteraction>();
+const mockKey = faker.string.alphanumeric({ length: 127 });
+const mockLeaderboardId = faker.string.alphanumeric();
+
+describe('Set aoc key', () => {
+  beforeEach(() => {
+    mockReset(mockChatInputInteraction);
+  });
+
+  it('should reply with error if it cannot set the key', async () => {
+    mockSetAocSettings.mockRejectedValueOnce(new Error('Synthetic Error'));
+    mockChatInputInteraction.options.getString.mockImplementation((name) => {
+      switch (name) {
+        case 'key': {
+          return mockKey;
+        }
+
+        case 'leaderboard-id': {
+          return mockLeaderboardId;
+        }
+
+        default:
+          return '';
+      }
+    });
+
+    await execute(mockChatInputInteraction);
+
+    expect(mockSetAocSettings).toHaveBeenCalledOnce();
+    expect(mockChatInputInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockChatInputInteraction.reply).toHaveBeenCalledWith('Cannot set this AOC key. Please try again');
+  });
+
+  it('Should be able to set AOC key and reply', async () => {
+    mockSetAocSettings.mockResolvedValueOnce({
+      guildId: faker.string.numeric(),
+      reminderChannel: null,
+      autobumpThreads: [],
+      aocLeaderboardId: faker.string.numeric(),
+    });
+    mockChatInputInteraction.options.getString.mockImplementation((name) => {
+      switch (name) {
+        case 'key': {
+          return mockKey;
+        }
+
+        case 'leaderboard-id': {
+          return mockLeaderboardId;
+        }
+
+        default:
+          return '';
+      }
+    });
+
+    await execute(mockChatInputInteraction);
+
+    expect(mockSetAocSettings).toHaveBeenCalledOnce();
+    expect(mockChatInputInteraction.reply).toHaveBeenCalledOnce();
+    expect(mockChatInputInteraction.reply).toHaveBeenCalledWith('Successfully saved setting. You can now get AOC Leaderboard.');
+  });
+});

--- a/src/slash-commands/server-settings/set-aoc-settings.ts
+++ b/src/slash-commands/server-settings/set-aoc-settings.ts
@@ -1,0 +1,35 @@
+import { SlashCommandSubcommandBuilder } from 'discord.js';
+import { Result } from 'oxide.ts';
+import { logger } from '../../utils/logger';
+import type { SlashCommandHandler, Subcommand } from '../builder';
+import { setAocSettings } from './utils';
+
+export const data = new SlashCommandSubcommandBuilder()
+  .setName('set-advent-of-code-key')
+  .setDescription('ADMIN COMMAND. Set key to get Advent of Code stats')
+  .addStringOption((option) => option.setName('key').setDescription('Advent of Code session key').setRequired(true))
+  .addStringOption((option) => option.setName('leaderboard-id').setDescription('Advent of Code leaderboard Id').setRequired(true));
+
+export const execute: SlashCommandHandler = async (interaction) => {
+  const guildId = interaction.guildId!;
+  const key = interaction.options.getString('key', true);
+  const leaderboardId = interaction.options.getString('leaderboard-id', true);
+  logger.info(`[set-aoc-key]: ${interaction.member!.user.username} is setting the Advent of Code key.`);
+
+  const op = await Result.safe(setAocSettings(guildId, key, leaderboardId));
+  if (op.isErr()) {
+    logger.info(`[set-aoc-key]: ${interaction.member!.user.username} failed to set AOC Key.`);
+    await interaction.reply('Cannot set this AOC key. Please try again');
+    return;
+  }
+
+  logger.info(`[set-aoc-key]: ${interaction.member!.user.username} successfully set AOC key for guild ${guildId}`);
+  await interaction.reply('Successfully saved setting. You can now get AOC Leaderboard.');
+};
+
+const command: Subcommand = {
+  data,
+  execute,
+};
+
+export default command;

--- a/src/slash-commands/server-settings/utils.ts
+++ b/src/slash-commands/server-settings/utils.ts
@@ -26,3 +26,12 @@ export const getReminderChannel = async (guildId: string) => {
 
   return serverSettings.reminderChannel;
 };
+
+export const setAocSettings = async (guildId: string, aocKey: string, aocLeaderboardId: string) => {
+  const db = getDbClient();
+  return db.serverChannelsSettings.upsert({
+    where: { guildId },
+    update: { aocKey, aocLeaderboardId },
+    create: { guildId, aocKey },
+  });
+};


### PR DESCRIPTION
- **feat: add aoc key and leaderboard id field**
- **feat: add command to set aoc settings**
- **feat: create function to fetch AOC data**
- **feat: add util functions to get and save leaderboard**
- **feat: add command to fetch leaderboard**
- **feat: add db migration for aoc models and settings**

## Description
- Add a command for admins to set aoc settings (leaderboard ID & session key)
- Add a command for everyone to get aoc results.

## Motivation and Context
Advent of Code is a common activity that VAIT members are participating in for the third year in a row now. Getting this into the server will be an easy way to keep track of the leaderboard.

## Related Issue
#243 

## How Has This Been Tested?
- Unit tests have all been ran
- Ran a test in the test server, see screenshots below.

## Screenshots (if appropriate):
<img width="825" alt="Screenshot 2024-12-15 at 2 48 49 am" src="https://github.com/user-attachments/assets/bb64055b-7af1-49b9-924a-5a74df41469f" />
The first one is a fresh request, the second one is a repeated request and it will only show the cached one.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
