### PR TITLE
feat: update command context and set default permissions for some commands to have manage member or channel perms

### DIFF
--- a/src/context-menu-commands/pin-message/index.ts
+++ b/src/context-menu-commands/pin-message/index.ts
@@ -1,9 +1,9 @@
-import { ApplicationCommandType, ContextMenuCommandBuilder, type ContextMenuCommandInteraction } from 'discord.js';
+import { ApplicationCommandType, ContextMenuCommandBuilder, type ContextMenuCommandInteraction, InteractionContextType } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
 import type { ContextMenuCommand } from '../builder';
 
-export const data = new ContextMenuCommandBuilder().setName('Pin').setType(ApplicationCommandType.Message);
+export const data = new ContextMenuCommandBuilder().setName('Pin').setType(ApplicationCommandType.Message).setContexts(InteractionContextType.Guild);
 
 export const pinMessage = async (interaction: ContextMenuCommandInteraction) => {
   if (!interaction.isMessageContextMenuCommand()) return;

--- a/src/slash-commands/8ball/index.ts
+++ b/src/slash-commands/8ball/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
 import { getRandomIntInclusive } from '../../utils/random';
 import type { SlashCommand } from '../builder';
@@ -6,7 +6,8 @@ import type { SlashCommand } from '../builder';
 const data = new SlashCommandBuilder()
   .setName('8ball')
   .setDescription('Ask the magic 8ball a question')
-  .addStringOption((option) => option.setName('question').setDescription('Question to ask the magic 8ball.').setRequired(true));
+  .addStringOption((option) => option.setName('question').setDescription('Question to ask the magic 8ball.').setRequired(true))
+  .setContexts(InteractionContextType.Guild);
 
 const REPLIES = [
   'Yes',

--- a/src/slash-commands/all-cap/index.ts
+++ b/src/slash-commands/all-cap/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder, type TextChannel } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder, type TextChannel } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
@@ -8,7 +8,8 @@ import type { SlashCommand } from '../builder';
 const data = new SlashCommandBuilder()
   .setName('allcap')
   .setDescription('Make your text L O O K S  L I K E  T H I S')
-  .addStringOption((option) => option.setName('sentence').setDescription('Sentence to All cap'));
+  .addStringOption((option) => option.setName('sentence').setDescription('Sentence to All cap'))
+  .setContexts(InteractionContextType.Guild);
 
 const generateAllCapText = (message: string) =>
   message

--- a/src/slash-commands/aoc-leaderboard/index.ts
+++ b/src/slash-commands/aoc-leaderboard/index.ts
@@ -1,7 +1,7 @@
 import type { AocLeaderboard } from '@prisma/client';
 import { differenceInMinutes } from 'date-fns';
 import { format } from 'date-fns';
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { DAY_MONTH_YEAR_HOUR_MINUTE_FORMAT } from '../../utils/date';
 import { logger } from '../../utils/logger';
@@ -12,7 +12,8 @@ export const DEFAULT_LEADERBOARD = 10;
 
 const data = new SlashCommandBuilder()
   .setName('aoc-leaderboard')
-  .setDescription("Fetch advent of code leaderboard. Will get current year, or the previous one if it isn't Dec yet.");
+  .setDescription("Fetch advent of code leaderboard. Will get current year, or the previous one if it isn't Dec yet.")
+  .setContexts(InteractionContextType.Guild);
 
 export function getAocYear(): number {
   const DECEMBER = 11;

--- a/src/slash-commands/autobump-threads/index.ts
+++ b/src/slash-commands/autobump-threads/index.ts
@@ -1,5 +1,4 @@
-import { type GuildMember, SlashCommandBuilder } from 'discord.js';
-import { isAdmin, isModerator } from '../../utils/permission';
+import { type GuildMember, InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import type { SlashCommand, SlashCommandHandler } from '../builder';
 import addThread from './add-thread';
 import listThreads from './list-threads';
@@ -8,6 +7,8 @@ import removeThread from './remove-thread';
 const data = new SlashCommandBuilder()
   .setName('autobump-threads')
   .setDescription('ADMIN ONLY COMMAND. Server Settings.')
+  .setContexts(InteractionContextType.Guild)
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
   .addSubcommand(listThreads.data)
   .addSubcommand(addThread.data)
   .addSubcommand(removeThread.data);
@@ -15,12 +16,6 @@ const data = new SlashCommandBuilder()
 const subcommands = [listThreads, addThread, removeThread];
 
 const execute: SlashCommandHandler = async (interaction) => {
-  const member = interaction.member as GuildMember;
-  if (!isAdmin(member) && !isModerator(member)) {
-    await interaction.reply("You don't have enough permission to run this command.");
-    return;
-  }
-
   const requestedSubcommand = interaction.options.getSubcommand(true);
   const subcommand = subcommands.find((cmd) => cmd.data.name === requestedSubcommand);
   return subcommand?.execute(interaction);

--- a/src/slash-commands/cowsay/index.ts
+++ b/src/slash-commands/cowsay/index.ts
@@ -1,5 +1,5 @@
 import { say } from 'cowsay';
-import { type ChatInputCommandInteraction, SlashCommandBuilder, type TextChannel } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder, type TextChannel } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
@@ -12,7 +12,8 @@ const WRAP_TEXT_LIMIT = 35;
 const data = new SlashCommandBuilder()
   .setName('cowsay')
   .setDescription('Make a cow say your chat message')
-  .addStringOption((option) => option.setName('sentence').setDescription('What you want the cow to say'));
+  .addStringOption((option) => option.setName('sentence').setDescription('What you want the cow to say'))
+  .setContexts(InteractionContextType.Guild);
 
 // Remove backtick in message in case of nesting cowsay
 export const removeBacktick = (message: string) => {

--- a/src/slash-commands/danh-someone/index.ts
+++ b/src/slash-commands/danh-someone/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
 import { getRandomBoolean, getRandomIntInclusive } from '../../utils/random';
 import type { SlashCommand } from '../builder';
@@ -9,7 +9,8 @@ const getData = () => {
   const data = new SlashCommandBuilder()
     .setName('hit')
     .setDescription('Hit up to 10 people. At least 1 user must be provided.')
-    .addUserOption((option) => option.setName('target1').setDescription('target 1 to hit').setRequired(true));
+    .addUserOption((option) => option.setName('target1').setDescription('target 1 to hit').setRequired(true))
+    .setContexts(InteractionContextType.Guild);
 
   for (const num of [...Array(MAX_MENTIONS).keys()]) {
     data.addUserOption((option) => option.setName(`target${num + 2}`).setDescription(`target ${num + 2} to hit`));

--- a/src/slash-commands/disclaimer/index.ts
+++ b/src/slash-commands/disclaimer/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, EmbedBuilder, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
 import type { SlashCommand } from '../builder';
 
@@ -12,7 +12,8 @@ const data = new SlashCommandBuilder()
       .setDescription('Choose a language for the disclaimer (Vietnamese / English)')
       .setRequired(true)
       .addChoices({ name: 'English', value: 'en' }, { name: 'Vietnamese', value: 'vi' })
-  );
+  )
+  .setContexts(InteractionContextType.Guild);
 
 export const DISCLAIMER_VI =
   'Trong trường hợp nhóm này bị điều tra bởi các cơ quan trực thuộc bộ công an (hoặc các tổ chức chính trị tương tự), tôi khẳng định mình không liên quan tới nhóm hoặc những cá nhân khác trong nhóm này. Tôi không rõ tại sao mình lại có mặt ở đây, có lẽ tài khoản của tôi đã được thêm bởi một bên thứ ba. Tôi cũng xin khẳng định rằng mình không hề giúp sức cho những hành động của các thành viên trong nhóm này.' as const;

--- a/src/slash-commands/insult/index.ts
+++ b/src/slash-commands/insult/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
 import type { SlashCommand } from '../builder';
@@ -7,7 +7,8 @@ import { randomInsultGenerator } from './insult-generator';
 const data = new SlashCommandBuilder()
   .setName('insult')
   .setDescription('Generate an insult. If a target is provided, it will insult them directly.')
-  .addStringOption((option) => option.setName('target').setDescription('The name to insult'));
+  .addStringOption((option) => option.setName('target').setDescription('The name to insult'))
+  .setContexts(InteractionContextType.Guild);
 
 export const insult = async (interaction: ChatInputCommandInteraction) => {
   const target = interaction.options.getString('target');

--- a/src/slash-commands/mock-someone/index.ts
+++ b/src/slash-commands/mock-someone/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder, type TextChannel } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder, type TextChannel } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
@@ -9,7 +9,8 @@ import type { SlashCommand } from '../builder';
 const data = new SlashCommandBuilder()
   .setName('mock')
   .setDescription('Mock a sentence. SpOnGeBoB sTyLe.')
-  .addStringOption((option) => option.setName('sentence').setDescription('The sentence to mock'));
+  .addStringOption((option) => option.setName('sentence').setDescription('The sentence to mock'))
+  .setContexts(InteractionContextType.Guild);
 
 const generateMockText = (message: string) =>
   message

--- a/src/slash-commands/moderate-users/index.test.ts
+++ b/src/slash-commands/moderate-users/index.test.ts
@@ -6,8 +6,6 @@ import { removeUserByRole } from '.';
 const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
 
 describe('Remove users who have the role', () => {
-  beforeAll(() => {});
-
   beforeEach(() => {
     mockReset(mockInteraction);
   });

--- a/src/slash-commands/moderate-users/index.test.ts
+++ b/src/slash-commands/moderate-users/index.test.ts
@@ -2,31 +2,14 @@ import { type APIRole, type ChatInputCommandInteraction, Collection, type Role, 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
 import { removeUserByRole } from '.';
-import { isAdmin, isModerator } from '../../utils/permission';
-
-vi.mock('../../utils/permission');
-const mockIsSentFromAdmin = vi.mocked(isAdmin);
-const mockIsSentFromModerator = vi.mocked(isModerator);
 
 const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
 
 describe('Remove users who have the role', () => {
-  beforeAll(() => {
-    mockIsSentFromAdmin.mockReturnValue(true);
-    mockIsSentFromModerator.mockReturnValue(true);
-  });
+  beforeAll(() => {});
 
   beforeEach(() => {
     mockReset(mockInteraction);
-  });
-
-  it('should reply with an error message if the user is not an admin or a moderator', async () => {
-    mockIsSentFromAdmin.mockReturnValueOnce(false);
-    mockIsSentFromModerator.mockReturnValueOnce(false);
-
-    await removeUserByRole(mockInteraction);
-
-    expect(mockInteraction.reply).toHaveBeenCalledWith("You don't have enough permission to run this command.");
   });
 
   it('should reply with an error message if the command is not executed in a thread', async () => {

--- a/src/slash-commands/moderate-users/index.ts
+++ b/src/slash-commands/moderate-users/index.ts
@@ -1,21 +1,23 @@
-import { type ChatInputCommandInteraction, type GuildMember, SlashCommandBuilder, type ThreadChannel } from 'discord.js';
+import {
+  type ChatInputCommandInteraction,
+  type GuildMember,
+  InteractionContextType,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+  type ThreadChannel,
+} from 'discord.js';
 import { logger } from '../../utils/logger';
-import { isAdmin, isModerator } from '../../utils/permission';
 import type { SlashCommand } from '../builder';
 
 const data = new SlashCommandBuilder()
   .setName('removeuserbyrole')
   .setDescription('Remove all users with a specific role from thread')
-  .addRoleOption((option) => option.setName('name').setDescription('Tag a role to remove the list of matching users').setRequired(true));
+  .addRoleOption((option) => option.setName('name').setDescription('Tag a role to remove the list of matching users').setRequired(true))
+  .setContexts(InteractionContextType.Guild)
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels);
 
 export const removeUserByRole = async (interaction: ChatInputCommandInteraction) => {
   const guildMember = interaction.member as GuildMember;
-  if (!isAdmin(guildMember) && !isModerator(guildMember)) {
-    logger.info(`[remove-user-by-role]: ${guildMember.user.tag} doesn't have enough permission to run this command.`);
-    await interaction.reply("You don't have enough permission to run this command.");
-    return;
-  }
-
   const channel = interaction.channel as ThreadChannel;
   if (!channel?.isThread()) {
     logger.info(`[remove-user-by-role]: ${guildMember.user.tag} tried to remove all users with role from entire channel.`);

--- a/src/slash-commands/powerball/index.ts
+++ b/src/slash-commands/powerball/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
 import { getRandomIntInclusive, getUniqueRandomIntInclusive } from '../../utils/random';
 import type { SlashCommand } from '../builder';
@@ -6,7 +6,8 @@ import type { SlashCommand } from '../builder';
 const data = new SlashCommandBuilder()
   .setName('powerball')
   .setDescription('Get some random Powerball numbers')
-  .addIntegerOption((option) => option.setName('count').setDescription('How many games do you need?').setRequired(true).setMinValue(1).setMaxValue(10));
+  .addIntegerOption((option) => option.setName('count').setDescription('How many games do you need?').setRequired(true).setMinValue(1).setMaxValue(10))
+  .setContexts(InteractionContextType.Guild);
 
 const MIN_POWER_BALL_NUMBER = 1;
 const MAX_POWER_BALL_NUMBER = 35;

--- a/src/slash-commands/quote-of-the-day/index.ts
+++ b/src/slash-commands/quote-of-the-day/index.ts
@@ -1,10 +1,10 @@
-import { type ChatInputCommandInteraction, EmbedBuilder, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, EmbedBuilder, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
 import type { SlashCommand } from '../builder';
 import { fetchQuote } from './fetch-quote';
 
-const data = new SlashCommandBuilder().setName('qotd').setDescription('Get Quote of the Day');
+const data = new SlashCommandBuilder().setName('qotd').setDescription('Get Quote of the Day').setContexts(InteractionContextType.Guild);
 
 export const getQuoteOfTheDay = async (interaction: ChatInputCommandInteraction) => {
   await interaction.deferReply();

--- a/src/slash-commands/referral/index.ts
+++ b/src/slash-commands/referral/index.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import type { AutocompleteHandler, SlashCommand, SlashCommandHandler } from '../builder';
 
 import * as referralNew from './referral-new';
@@ -13,7 +13,8 @@ const getData = () => {
     .setName('referral')
     .setDescription('Get referral code or link for services')
     .addSubcommand(referralNew.data)
-    .addSubcommand(referralRandom.data);
+    .addSubcommand(referralRandom.data)
+    .setContexts(InteractionContextType.Guild);
 
   return data;
 };

--- a/src/slash-commands/reminder/index.ts
+++ b/src/slash-commands/reminder/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import type { SlashCommand } from '../builder';
 import list from './list';
 import remindDuration from './remind-duration';
@@ -9,6 +9,7 @@ import update from './update';
 const data = new SlashCommandBuilder()
   .setName('reminder')
   .setDescription('Set up a reminder')
+  .setContexts(InteractionContextType.Guild)
   .addSubcommand(remindOnDate.data)
   .addSubcommand(remindDuration.data)
   .addSubcommand(update.data)

--- a/src/slash-commands/reputation/index.ts
+++ b/src/slash-commands/reputation/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import type { SlashCommand } from '../builder';
 import checkRep from './check-reputation';
 import giveRep from './give-reputation';
@@ -9,6 +9,7 @@ import takeRep from './take-reputation';
 const data = new SlashCommandBuilder()
   .setName('rep')
   .setDescription('Reputation module')
+  .setContexts(InteractionContextType.Guild)
   .addSubcommand(checkRep.data)
   .addSubcommand(giveRep.data)
   .addSubcommand(takeRep.data)

--- a/src/slash-commands/server-settings/index.ts
+++ b/src/slash-commands/server-settings/index.ts
@@ -1,5 +1,4 @@
-import { type GuildMember, SlashCommandBuilder } from 'discord.js';
-import { isAdmin, isModerator } from '../../utils/permission';
+import { type GuildMember, InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import type { SlashCommand, SlashCommandHandler } from '../builder';
 import setAocSettings from './set-aoc-settings';
 import setReminderChannel from './set-reminder-channel';
@@ -8,17 +7,13 @@ const data = new SlashCommandBuilder()
   .setName('server-settings')
   .setDescription('ADMIN ONLY COMMAND. Server Settings.')
   .addSubcommand(setReminderChannel.data)
-  .addSubcommand(setAocSettings.data);
+  .addSubcommand(setAocSettings.data)
+  .setContexts(InteractionContextType.Guild)
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels);
 
 const subcommands = [setReminderChannel, setAocSettings];
 
 const execute: SlashCommandHandler = async (interaction) => {
-  const member = interaction.member as GuildMember;
-  if (!isAdmin(member) && !isModerator(member)) {
-    await interaction.reply("You don't have enough permission to run this command.");
-    return;
-  }
-
   const requestedSubcommand = interaction.options.getSubcommand(true);
   const subcommand = subcommands.find((cmd) => cmd.data.name === requestedSubcommand);
   return subcommand?.execute(interaction);

--- a/src/slash-commands/weather/index.ts
+++ b/src/slash-commands/weather/index.ts
@@ -1,4 +1,4 @@
-import { type ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
@@ -10,7 +10,8 @@ export const DEFAULT_LOCATION = 'Brisbane';
 const data = new SlashCommandBuilder()
   .setName('weather')
   .setDescription('Get current weather report at location')
-  .addStringOption((option) => option.setName('location').setDescription('The location you want a weather report on. Default: Brisbane'));
+  .addStringOption((option) => option.setName('location').setDescription('The location you want a weather report on. Default: Brisbane'))
+  .setContexts(InteractionContextType.Guild);
 
 export const weather = async (interaction: ChatInputCommandInteraction) => {
   await interaction.deferReply();

--- a/src/utils/permission.test.ts
+++ b/src/utils/permission.test.ts
@@ -1,4 +1,4 @@
-import { Collection, type GuildMember, type Role } from 'discord.js';
+import { Collection, type GuildMember, PermissionFlagsBits, type Role } from 'discord.js';
 import { describe, expect, it } from 'vitest';
 import { isAdmin, isModerator } from './permission';
 
@@ -40,8 +40,22 @@ describe('isAdmin', () => {
   });
 
   it('Should return false for user without permissions', () => {
-    const fakeMember = { permissions: { has: () => false } } as unknown as GuildMember;
+    const fakeMember = {
+      permissions: { has: () => false },
+    } as unknown as GuildMember;
     const output = isAdmin(fakeMember);
     expect(output).toBeFalsy();
+  });
+
+  it('Should return true for user with admin permissions', () => {
+    const fakeMember = {
+      permissions: {
+        has: (flag: bigint): boolean => {
+          return flag === PermissionFlagsBits.Administrator;
+        },
+      },
+    } as unknown as GuildMember;
+    const output = isAdmin(fakeMember);
+    expect(output).toBeTruthy();
   });
 });

--- a/src/utils/permission.ts
+++ b/src/utils/permission.ts
@@ -1,10 +1,10 @@
 import type { GuildMember } from 'discord.js';
-import { PermissionsBitField } from 'discord.js';
+import { PermissionFlagsBits } from 'discord.js';
 
 export const isAdmin = (member: GuildMember | null) => {
   if (!member) return false;
 
-  return member.permissions.has(PermissionsBitField.Flags.Administrator);
+  return member.permissions.has(PermissionFlagsBits.Administrator);
 };
 
 export const isModerator = (member: GuildMember | null) => {


### PR DESCRIPTION
This is because Discord.js now introduces a way to bound slash commands to a specific context
(Mainly between Guild-only, DMs-only or private channels) for global commands. This change will
make all our commands only appear within the guilds and not DMs, greatly simplifying the permission
control process to be more inline with Discord platform rules, and as recommended by Discord.js guide:

> Your code should not try to enforce its own permission management, as this can result in a conflict
> between the server-configured permissions and your bot's code.

However, there's a specific caveat to this as this can only be set at the root command level
and not in subcommands, so some admin-only subcommands like `/rep set` and `/rep take` still
needs manual permissions control.

Reference: https://discordjs.guide/slash-commands/permissions.html#member-permissions
