### PR TITLE
test: create reusuable test fixtures to use with tests across the repo

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,9 @@
       "suspicious": {
         "noExplicitAny": "off"
       },
+      "correctness": {
+        "noEmptyPattern": "off"
+      },
       "style": {
         "noNonNullAssertion": "off"
       }

--- a/src/context-menu-commands/pin-message/index.test.ts
+++ b/src/context-menu-commands/pin-message/index.test.ts
@@ -1,36 +1,34 @@
-import type { ContextMenuCommandInteraction, MessageContextMenuCommandInteraction } from 'discord.js';
-import { describe, expect, it } from 'vitest';
+import type { Message } from 'discord.js';
+import { describe, expect } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { pinMessage } from '.';
+import { contextMenuCommandTest } from '../../../test/fixtures/context-menu-command-interaction';
 
 describe('pinMessage context menu test', () => {
-  it('Should return if interaction is not message context menu command', async () => {
-    const mockInteraction = mockDeep<ContextMenuCommandInteraction>();
-    mockInteraction.isMessageContextMenuCommand.mockReturnValueOnce(false);
+  contextMenuCommandTest('Should return if interaction is not message context menu command', async ({ interaction }) => {
+    interaction.isMessageContextMenuCommand.mockReturnValueOnce(false);
 
-    await pinMessage(mockInteraction as ContextMenuCommandInteraction);
-    expect(mockInteraction.reply).not.toHaveBeenCalled();
+    await pinMessage(interaction);
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
-  it('Should reply skipping if message is already pinned', async () => {
-    const mockInteraction = mockDeep<MessageContextMenuCommandInteraction>();
-    mockInteraction.isMessageContextMenuCommand.mockReturnValueOnce(true);
-    mockInteraction.targetMessage.pinned = true;
+  contextMenuCommandTest('Should reply skipping if message is already pinned', async ({ interaction }) => {
+    interaction.isMessageContextMenuCommand.mockReturnValueOnce(true);
+    interaction.targetMessage.pinned = true;
 
-    await pinMessage(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('Message is already pinned. Skipping...');
+    await pinMessage(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Message is already pinned. Skipping...');
   });
 
-  it('Should pin the message', async () => {
-    const mockInteraction = mockDeep<MessageContextMenuCommandInteraction>();
-    mockInteraction.isMessageContextMenuCommand.mockReturnValueOnce(true);
-    mockInteraction.targetMessage.pinned = false;
-    mockInteraction.targetMessage.pin.mockResolvedValueOnce({} as any);
+  contextMenuCommandTest('Should pin the message', async ({ interaction }) => {
+    interaction.isMessageContextMenuCommand.mockReturnValueOnce(true);
+    interaction.targetMessage.pinned = false;
+    interaction.targetMessage.pin.mockResolvedValueOnce(mockDeep<Message<true>>());
 
-    await pinMessage(mockInteraction);
-    expect(mockInteraction.targetMessage.pin).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('Message is now pinned!');
+    await pinMessage(interaction);
+    expect(interaction.targetMessage.pin).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Message is now pinned!');
   });
 });

--- a/src/slash-commands/8ball/index.test.ts
+++ b/src/slash-commands/8ball/index.test.ts
@@ -1,20 +1,13 @@
 import { faker } from '@faker-js/faker';
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect } from 'vitest';
 import { ask8Ball } from '.';
-
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
 describe('ask 8Ball test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
+  chatInputCommandInteractionTest('Should return yes or no randomly for any question', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce(faker.lorem.words(25));
 
-  it('Should return yes or no randomly for any question', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce(faker.lorem.words(25));
-
-    await ask8Ball(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    await ask8Ball(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
   });
 });

--- a/src/slash-commands/all-cap/index.test.ts
+++ b/src/slash-commands/all-cap/index.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { mock, mockDeep, mockReset } from 'vitest-mock-extended';
 import { allCapExpandText } from '.';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const mockMessage = mock<Message<true>>();
 
 describe('All caps test', () => {

--- a/src/slash-commands/all-cap/index.test.ts
+++ b/src/slash-commands/all-cap/index.test.ts
@@ -1,48 +1,40 @@
 import { faker } from '@faker-js/faker';
-import { type ChatInputCommandInteraction, Collection, type Message } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { mock, mockDeep, mockReset } from 'vitest-mock-extended';
+import { Collection, type Message } from 'discord.js';
+import { describe, expect } from 'vitest';
 import { allCapExpandText } from '.';
-
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-const mockMessage = mock<Message<true>>();
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
 describe('All caps test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockReset(mockMessage);
-  });
+  chatInputCommandInteractionTest('Should return text app cap and expanded', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('aaa');
 
-  it('Should return text app cap and expanded', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('aaa');
-
-    await allCapExpandText(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toBeCalledWith('A A A ');
+    await allCapExpandText(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toBeCalledWith('A A A ');
   });
 
   describe('All cap with no content', () => {
     describe('Fetch the previous message', () => {
-      it('Should refer to previous message', async () => {
-        mockMessage.content = 'aaa';
-        const mockMessageCollection = new Collection<string, Message<true>>();
-        mockMessageCollection.set(faker.string.nanoid(), mockMessage);
-        mockInteraction.options.getString.mockReturnValueOnce('');
-        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(mockMessageCollection);
+      chatInputCommandInteractionTest('Should refer to previous message', async ({ interaction, message }) => {
+        message.content = 'aaa';
+        const messageCollection = new Collection<string, Message<true>>();
+        messageCollection.set(faker.string.nanoid(), message);
+        interaction.options.getString.mockReturnValueOnce('');
+        interaction.channel?.messages.fetch.mockResolvedValueOnce(messageCollection);
 
-        await allCapExpandText(mockInteraction);
-        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toBeCalledWith('A A A ');
+        await allCapExpandText(interaction);
+        expect(interaction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(interaction.reply).toBeCalledWith('A A A ');
       });
 
-      it('Should show error message if there is no previous message', async () => {
-        const mockMessageCollection = new Collection<string, Message<true>>();
-        mockInteraction.options.getString.mockReturnValueOnce('');
-        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(mockMessageCollection);
+      chatInputCommandInteractionTest('Should show error message if there is no previous message', async ({ interaction }) => {
+        const messageCollection = new Collection<string, Message<true>>();
+        interaction.options.getString.mockReturnValueOnce('');
+        interaction.channel?.messages.fetch.mockResolvedValueOnce(messageCollection);
 
-        await allCapExpandText(mockInteraction);
-        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toBeCalledWith('Cannot fetch latest message. Please try again later.');
+        await allCapExpandText(interaction);
+        expect(interaction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(interaction.reply).toBeCalledWith('Cannot fetch latest message. Please try again later.');
       });
     });
   });

--- a/src/slash-commands/aoc-leaderboard/index.test.ts
+++ b/src/slash-commands/aoc-leaderboard/index.test.ts
@@ -1,14 +1,13 @@
 import { faker } from '@faker-js/faker';
-import type { ChatInputCommandInteraction } from 'discord.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
+import { captor } from 'vitest-mock-extended';
 import { execute, formatLeaderboard, getAocYear } from '.';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { setAocSettings } from '../server-settings/utils';
 import mockAocData from './sample/aoc-data.json';
 import { AocLeaderboard } from './schema';
 import { deleteLeaderboard, saveLeaderboard } from './utils';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const parsedMockData = AocLeaderboard.parse(mockAocData);
 const mockKey = faker.string.alphanumeric({ length: 127 });
 const mockLeaderboardId = faker.string.alphanumeric();
@@ -16,10 +15,6 @@ const mockLeaderboardId = faker.string.alphanumeric();
 const mockSystemTime = new Date(2024, 11, 25, 16, 0, 0); // 25/12/2024 16:00:00
 
 describe('Get AOC Leaderboard test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
   describe('Static time tests', () => {
     beforeEach(() => {
       vi.useFakeTimers();
@@ -68,15 +63,13 @@ Last updated at: 25/12/2024 16:00
   });
 
   describe('Command tests', () => {
-    it('Should reply with saved leaderboard if it can get one', async () => {
-      const guildId = faker.string.nanoid();
-      await saveLeaderboard(guildId, parsedMockData);
-      mockInteraction.guildId = guildId;
+    chatInputCommandInteractionTest('Should reply with saved leaderboard if it can get one', async ({ interaction }) => {
+      await saveLeaderboard(interaction.guildId!, parsedMockData);
 
-      await execute(mockInteraction);
+      await execute(interaction);
 
       const message = captor<string>();
-      expect(mockInteraction.editReply).toHaveBeenCalledWith(message);
+      expect(interaction.editReply).toHaveBeenCalledWith(message);
       expect(message.value).toContain(`
  #               name score
  1 (anonymous user 4) 474
@@ -85,31 +78,22 @@ Last updated at: 25/12/2024 16:00
  4              user1   0
 `);
 
-      await deleteLeaderboard(guildId);
+      await deleteLeaderboard(interaction.guildId!);
     });
 
-    it('Should reply with error if server is not configured', async () => {
-      const guildId = faker.string.nanoid();
-      mockInteraction.guildId = guildId;
+    chatInputCommandInteractionTest('Should reply with error if server is not configured', async ({ interaction }) => {
+      await execute(interaction);
 
-      await execute(mockInteraction);
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith('ERROR: Server is not configured to get AOC results! Missing Key and/or Leaderboard ID.');
+      expect(interaction.editReply).toHaveBeenCalledWith('ERROR: Server is not configured to get AOC results! Missing Key and/or Leaderboard ID.');
     });
 
-    it('Should reply with newly fetched leaderboard after fetching and saving', async () => {
-      const guildId = faker.string.nanoid();
-      await setAocSettings(guildId, mockKey, mockLeaderboardId);
-      mockInteraction.guildId = guildId;
+    chatInputCommandInteractionTest('Should reply with newly fetched leaderboard after fetching and saving', async ({ interaction }) => {
+      await setAocSettings(interaction.guildId!, mockKey, mockLeaderboardId);
 
-      const result = execute(mockInteraction);
-
-      vi.runAllTimers();
-
-      await result;
+      await execute(interaction);
 
       const message = captor<string>();
-      expect(mockInteraction.editReply).toHaveBeenCalledWith(message);
+      expect(interaction.editReply).toHaveBeenCalledWith(message);
       expect(message.value).toContain(`
  #               name score
  1 (anonymous user 4) 474

--- a/src/slash-commands/aoc-leaderboard/index.test.ts
+++ b/src/slash-commands/aoc-leaderboard/index.test.ts
@@ -102,7 +102,11 @@ Last updated at: 25/12/2024 16:00
       await setAocSettings(guildId, mockKey, mockLeaderboardId);
       mockInteraction.guildId = guildId;
 
-      await execute(mockInteraction);
+      const result = execute(mockInteraction);
+
+      vi.runAllTimers();
+
+      await result;
 
       const message = captor<string>();
       expect(mockInteraction.editReply).toHaveBeenCalledWith(message);

--- a/src/slash-commands/autobump-threads/add-thread.test.ts
+++ b/src/slash-commands/autobump-threads/add-thread.test.ts
@@ -1,8 +1,12 @@
 import { ChannelType, type PublicThreadChannel, type TextChannel } from 'discord.js';
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { addAutobumpThreadCommand } from './add-thread';
+import { addAutobumpThread } from './utils';
+
+vi.mock('./utils');
+const mockAddAutobumpThread = vi.mocked(addAutobumpThread);
 
 const threadId = 'thread_1234';
 
@@ -18,12 +22,25 @@ describe('Add autobump thread', () => {
     expect(interaction.reply).toBeCalledWith(`ERROR: The channel <#${mockChannel.id}> is not a thread.`);
   });
 
+  chatInputCommandInteractionTest('Should reply with error if it cannot be saved into the database', async ({ interaction }) => {
+    const mockChannel = mockDeep<PublicThreadChannel>();
+    mockChannel.id = threadId;
+    mockChannel.type = ChannelType.PublicThread;
+    interaction.options.getChannel.mockReturnValueOnce(mockChannel);
+    mockAddAutobumpThread.mockRejectedValueOnce(new Error('Synthetic Error'));
+
+    await addAutobumpThreadCommand(interaction);
+    expect(interaction.reply).toBeCalledWith('ERROR: Cannot save this thread to be autobumped for this server. Please try again.');
+    expect(mockAddAutobumpThread).toBeCalled();
+  });
+
   chatInputCommandInteractionTest('Should reply with success message if it can be saved into the database', async ({ interaction }) => {
     const mockChannel = mockDeep<PublicThreadChannel>();
     mockChannel.id = threadId;
     mockChannel.type = ChannelType.PublicThread;
     mockChannel.guildId = interaction.guildId!;
     interaction.options.getChannel.mockReturnValueOnce(mockChannel);
+    mockAddAutobumpThread.mockResolvedValueOnce([threadId]);
 
     await addAutobumpThreadCommand(interaction);
     expect(interaction.reply).toBeCalledWith(`Successfully saved setting. Thread <#${threadId}> will be autobumped.`);

--- a/src/slash-commands/autobump-threads/add-thread.test.ts
+++ b/src/slash-commands/autobump-threads/add-thread.test.ts
@@ -2,12 +2,10 @@ import { ChannelType, type ChatInputCommandInteraction, type PublicThreadChannel
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep, mockReset } from 'vitest-mock-extended';
 import { addAutobumpThreadCommand } from './add-thread';
-import { addAutobumpThread } from './utils';
 
-vi.mock('./utils');
-const mockAddAutobumpThread = vi.mocked(addAutobumpThread);
 const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const threadId = 'thread_1234';
+const guildId = '1234';
 
 describe('Add autobump thread', () => {
   beforeEach(() => {
@@ -17,34 +15,21 @@ describe('Add autobump thread', () => {
   it('Should reply with error if the given channel is not a thread', async () => {
     const mockChannel = mockDeep<TextChannel>();
     mockChannel.id = 'channel_1234';
+    mockChannel.type = ChannelType.GuildText;
     mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
 
     await addAutobumpThreadCommand(mockInteraction);
     expect(mockInteraction.reply).toBeCalledWith(`ERROR: The channel <#${mockChannel.id}> is not a thread.`);
-    expect(mockAddAutobumpThread).not.toBeCalled();
-  });
-
-  it('Should reply with error if it cannot be saved into the database', async () => {
-    const mockChannel = mockDeep<PublicThreadChannel>();
-    mockChannel.id = threadId;
-    mockChannel.type = ChannelType.PublicThread;
-    mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
-    mockAddAutobumpThread.mockRejectedValueOnce(new Error('Synthetic Error'));
-
-    await addAutobumpThreadCommand(mockInteraction);
-    expect(mockInteraction.reply).toBeCalledWith('ERROR: Cannot save this thread to be autobumped for this server. Please try again.');
-    expect(mockAddAutobumpThread).toBeCalled();
   });
 
   it('Should reply with success message if it can be saved into the database', async () => {
     const mockChannel = mockDeep<PublicThreadChannel>();
     mockChannel.id = threadId;
     mockChannel.type = ChannelType.PublicThread;
+    mockInteraction.guildId = guildId;
     mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
-    mockAddAutobumpThread.mockResolvedValueOnce([threadId]);
 
     await addAutobumpThreadCommand(mockInteraction);
     expect(mockInteraction.reply).toBeCalledWith(`Successfully saved setting. Thread <#${threadId}> will be autobumped.`);
-    expect(mockAddAutobumpThread).toBeCalled();
   });
 });

--- a/src/slash-commands/autobump-threads/add-thread.test.ts
+++ b/src/slash-commands/autobump-threads/add-thread.test.ts
@@ -1,35 +1,31 @@
-import { ChannelType, type ChatInputCommandInteraction, type PublicThreadChannel, type TextChannel } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { ChannelType, type PublicThreadChannel, type TextChannel } from 'discord.js';
+import { describe, expect } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { addAutobumpThreadCommand } from './add-thread';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const threadId = 'thread_1234';
-const guildId = '1234';
 
 describe('Add autobump thread', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('Should reply with error if the given channel is not a thread', async () => {
+  chatInputCommandInteractionTest('Should reply with error if the given channel is not a thread', async ({ interaction }) => {
     const mockChannel = mockDeep<TextChannel>();
     mockChannel.id = 'channel_1234';
     mockChannel.type = ChannelType.GuildText;
-    mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
+    mockChannel.guildId = interaction.guildId!;
+    interaction.options.getChannel.mockReturnValueOnce(mockChannel);
 
-    await addAutobumpThreadCommand(mockInteraction);
-    expect(mockInteraction.reply).toBeCalledWith(`ERROR: The channel <#${mockChannel.id}> is not a thread.`);
+    await addAutobumpThreadCommand(interaction);
+    expect(interaction.reply).toBeCalledWith(`ERROR: The channel <#${mockChannel.id}> is not a thread.`);
   });
 
-  it('Should reply with success message if it can be saved into the database', async () => {
+  chatInputCommandInteractionTest('Should reply with success message if it can be saved into the database', async ({ interaction }) => {
     const mockChannel = mockDeep<PublicThreadChannel>();
     mockChannel.id = threadId;
     mockChannel.type = ChannelType.PublicThread;
-    mockInteraction.guildId = guildId;
-    mockInteraction.options.getChannel.mockReturnValueOnce(mockChannel);
+    mockChannel.guildId = interaction.guildId!;
+    interaction.options.getChannel.mockReturnValueOnce(mockChannel);
 
-    await addAutobumpThreadCommand(mockInteraction);
-    expect(mockInteraction.reply).toBeCalledWith(`Successfully saved setting. Thread <#${threadId}> will be autobumped.`);
+    await addAutobumpThreadCommand(interaction);
+    expect(interaction.reply).toBeCalledWith(`Successfully saved setting. Thread <#${threadId}> will be autobumped.`);
   });
 });

--- a/src/slash-commands/autobump-threads/index.ts
+++ b/src/slash-commands/autobump-threads/index.ts
@@ -1,4 +1,4 @@
-import { type GuildMember, InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import { InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import type { SlashCommand, SlashCommandHandler } from '../builder';
 import addThread from './add-thread';
 import listThreads from './list-threads';

--- a/src/slash-commands/autobump-threads/list-threads.test.ts
+++ b/src/slash-commands/autobump-threads/list-threads.test.ts
@@ -1,48 +1,41 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { listAutobumpThreadsCommand } from './list-threads';
 import { listThreadsByGuild } from './utils';
 
 vi.mock('./utils');
 const mockListAutobumpThread = vi.mocked(listThreadsByGuild);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const threadId = 'thread_1234';
-const guildId = '1234';
 
 describe('List autobump threads', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('Should reply with error if the server settings cannot be retrieved', async () => {
+  chatInputCommandInteractionTest('Should reply with error if the server settings cannot be retrieved', async ({ interaction }) => {
     mockListAutobumpThread.mockRejectedValueOnce(new Error('Synthetic Error'));
 
-    await listAutobumpThreadsCommand(mockInteraction);
+    await listAutobumpThreadsCommand(interaction);
 
     expect(mockListAutobumpThread).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith("ERROR: Cannot get list of threads from the database, maybe the server threads aren't setup yet?");
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith("ERROR: Cannot get list of threads from the database, maybe the server threads aren't setup yet?");
   });
 
-  it('Should reply with empty message if no autobump thread has been set', async () => {
+  chatInputCommandInteractionTest('Should reply with empty message if no autobump thread has been set', async ({ interaction }) => {
     mockListAutobumpThread.mockResolvedValueOnce([]);
 
-    await listAutobumpThreadsCommand(mockInteraction);
+    await listAutobumpThreadsCommand(interaction);
 
     expect(mockListAutobumpThread).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('ERROR: No threads have been setup for autobumping in this server');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('ERROR: No threads have been setup for autobumping in this server');
   });
 
-  it('Should reply with list of autobump thread if it has been set', async () => {
+  chatInputCommandInteractionTest('Should reply with list of autobump thread if it has been set', async ({ interaction }) => {
     mockListAutobumpThread.mockResolvedValueOnce([threadId]);
 
-    await listAutobumpThreadsCommand(mockInteraction);
+    await listAutobumpThreadsCommand(interaction);
 
     expect(mockListAutobumpThread).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `Here is the threads to be autobumped in this server:
 - <#${threadId}>
 `

--- a/src/slash-commands/autobump-threads/remove-thread.test.ts
+++ b/src/slash-commands/autobump-threads/remove-thread.test.ts
@@ -1,37 +1,27 @@
-import type { ChatInputCommandInteraction, PublicThreadChannel } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, it, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { removeAutobumpThreadCommand } from './remove-thread';
 import { removeAutobumpThread } from './utils';
 
 vi.mock('./utils');
 const mockRemoveAutobumpThread = vi.mocked(removeAutobumpThread);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-const mockThread = mockDeep<PublicThreadChannel>();
-const threadId = 'thread_1234';
 
 describe('Add autobump thread', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockReset(mockThread);
-    mockThread.id = threadId;
-  });
-
-  it('Should reply with error if it cannot be saved into the database', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce(mockThread);
+  chatInputCommandInteractionTest('Should reply with error if it cannot be saved into the database', async ({ interaction, thread }) => {
+    interaction.options.getChannel.mockReturnValueOnce(thread);
     mockRemoveAutobumpThread.mockRejectedValueOnce(new Error('Synthetic Error'));
 
-    await removeAutobumpThreadCommand(mockInteraction);
-    expect(mockInteraction.reply).toBeCalledWith(`ERROR: Cannot remove thread id <#${threadId}> from the bump list for this server. Please try again.`);
+    await removeAutobumpThreadCommand(interaction);
+    expect(interaction.reply).toBeCalledWith(`ERROR: Cannot remove thread id <#${thread.id}> from the bump list for this server. Please try again.`);
     expect(mockRemoveAutobumpThread).toBeCalled();
   });
 
-  it('Should reply with success message if it can be saved into the database', async () => {
-    mockInteraction.options.getChannel.mockReturnValueOnce(mockThread);
-    mockRemoveAutobumpThread.mockResolvedValueOnce([threadId]);
+  chatInputCommandInteractionTest('Should reply with success message if it can be saved into the database', async ({ interaction, thread }) => {
+    interaction.options.getChannel.mockReturnValueOnce(thread);
+    mockRemoveAutobumpThread.mockResolvedValueOnce([thread.id]);
 
-    await removeAutobumpThreadCommand(mockInteraction);
-    expect(mockInteraction.reply).toBeCalledWith(`Successfully saved setting. Thread <#${threadId}> will not be bumped.`);
+    await removeAutobumpThreadCommand(interaction);
+    expect(interaction.reply).toBeCalledWith(`Successfully saved setting. Thread <#${thread.id}> will not be bumped.`);
     expect(mockRemoveAutobumpThread).toBeCalled();
   });
 });

--- a/src/slash-commands/autobump-threads/remove-thread.test.ts
+++ b/src/slash-commands/autobump-threads/remove-thread.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { removeAutobumpThreadCommand } from './remove-thread';
 import { removeAutobumpThread } from './utils';

--- a/src/slash-commands/cowsay/index.test.ts
+++ b/src/slash-commands/cowsay/index.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { mock, mockDeep, mockReset } from 'vitest-mock-extended';
 import { cowsay, removeBacktick } from '.';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const mockMessage = mock<Message<true>>();
 
 describe('Remove backtick test', () => {

--- a/src/slash-commands/danh-someone/index.test.ts
+++ b/src/slash-commands/danh-someone/index.test.ts
@@ -1,47 +1,46 @@
-import type { ChatInputCommandInteraction, User } from 'discord.js';
-import { describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import type { User } from 'discord.js';
+import { describe, expect, vi } from 'vitest';
 import { danhSomeone } from '.';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { getRandomBoolean, getRandomIntInclusive } from '../../utils/random';
 
 vi.mock('../../utils/random');
 const mockRandomInt = vi.mocked(getRandomIntInclusive);
 const mockRandomBoolean = vi.mocked(getRandomBoolean);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('danhSomeone', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockInteraction.client.user.id = '1';
-    mockInteraction.member!.user.id = '2';
-  });
-
-  it('should not allow user to hit bot', () => {
-    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+  chatInputCommandInteractionTest('should not allow user to hit bot', ({ interaction }) => {
+    interaction.client.user.id = '1';
+    interaction.member!.user.id = '2';
+    interaction.options.getUser.mockImplementationOnce((param: string) => {
       if (param === 'target1') return { id: '1' } as User;
 
       return null;
     });
 
-    danhSomeone(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith("<@2>, I'm your father, you can't hit me.");
+    danhSomeone(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith("<@2>, I'm your father, you can't hit me.");
   });
 
-  it('should not allow user to hit themself', () => {
-    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+  chatInputCommandInteractionTest('should not allow user to hit themself', ({ interaction }) => {
+    interaction.client.user.id = '1';
+    interaction.member!.user.id = '2';
+    interaction.options.getUser.mockImplementationOnce((param: string) => {
       if (param === 'target1') return { id: '2' } as User;
 
       return null;
     });
 
-    danhSomeone(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('Stop hitting yourself <@2>, hit someone else.');
+    danhSomeone(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Stop hitting yourself <@2>, hit someone else.');
   });
 
-  it('should allow user to hit someone else', () => {
-    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+  chatInputCommandInteractionTest('should allow user to hit someone else', ({ interaction }) => {
+    interaction.client.user.id = '1';
+    interaction.member!.user.id = '2';
+    interaction.options.getUser.mockImplementationOnce((param: string) => {
       if (param === 'target1') return { id: '3' } as User;
 
       return null;
@@ -49,13 +48,15 @@ describe('danhSomeone', () => {
     mockRandomInt.mockReturnValueOnce(1);
     mockRandomBoolean.mockReturnValueOnce(false);
 
-    danhSomeone(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('<@3> takes 1 dmg.');
+    danhSomeone(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('<@3> takes 1 dmg.');
   });
 
-  it('should allow user to hit someone else with a crit', () => {
-    mockInteraction.options.getUser.mockImplementationOnce((param: string) => {
+  chatInputCommandInteractionTest('should allow user to hit someone else with a crit', ({ interaction }) => {
+    interaction.client.user.id = '1';
+    interaction.member!.user.id = '2';
+    interaction.options.getUser.mockImplementationOnce((param: string) => {
       if (param === 'target1') return { id: '3' } as User;
 
       return null;
@@ -63,13 +64,15 @@ describe('danhSomeone', () => {
     mockRandomInt.mockReturnValueOnce(1);
     mockRandomBoolean.mockReturnValueOnce(true);
 
-    danhSomeone(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('<@3> takes 1 dmg. Critical Hit!');
+    danhSomeone(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('<@3> takes 1 dmg. Critical Hit!');
   });
 
-  it('should allow user to hit many people', () => {
-    mockInteraction.options.getUser
+  chatInputCommandInteractionTest('should allow user to hit many people', ({ interaction }) => {
+    interaction.client.user.id = '1';
+    interaction.member!.user.id = '2';
+    interaction.options.getUser
       .mockReturnValueOnce({ id: '3' } as User)
       .mockReturnValueOnce({ id: '4' } as User)
       .mockReturnValueOnce({ id: '5' } as User)
@@ -83,9 +86,9 @@ describe('danhSomeone', () => {
     mockRandomInt.mockReturnValue(1);
     mockRandomBoolean.mockReturnValueOnce(false);
 
-    danhSomeone(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    danhSomeone(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `<@3> takes 1 dmg.
 <@4> takes 1 dmg.
 <@5> takes 1 dmg.

--- a/src/slash-commands/danh-someone/index.test.ts
+++ b/src/slash-commands/danh-someone/index.test.ts
@@ -7,13 +7,13 @@ import { getRandomBoolean, getRandomIntInclusive } from '../../utils/random';
 vi.mock('../../utils/random');
 const mockRandomInt = vi.mocked(getRandomIntInclusive);
 const mockRandomBoolean = vi.mocked(getRandomBoolean);
-const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('danhSomeone', () => {
   beforeEach(() => {
     mockReset(mockInteraction);
     mockInteraction.client.user.id = '1';
-    mockInteraction.member.user.id = '2';
+    mockInteraction.member!.user.id = '2';
   });
 
   it('should not allow user to hit bot', () => {

--- a/src/slash-commands/disclaimer/index.test.ts
+++ b/src/slash-commands/disclaimer/index.test.ts
@@ -1,9 +1,8 @@
-import { type ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { EmbedBuilder } from 'discord.js';
+import { describe, expect } from 'vitest';
 import { DISCLAIMER_EN, DISCLAIMER_VI, getDisclaimer } from '.';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const getEmbed = (content: string) => {
   return new EmbedBuilder({
     author: {
@@ -14,26 +13,22 @@ const getEmbed = (content: string) => {
 };
 
 describe('get disclaimer test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
+  chatInputCommandInteractionTest('Should return the disclaimer text', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('');
 
-  it('Should return the disclaimer text', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('');
-
-    await getDisclaimer(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith({
+    await getDisclaimer(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith({
       embeds: [getEmbed(DISCLAIMER_VI)],
     });
   });
 
-  it('Should return the EN disclaimer text', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('en');
+  chatInputCommandInteractionTest('Should return the EN disclaimer text', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('en');
 
-    await getDisclaimer(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith({
+    await getDisclaimer(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith({
       embeds: [getEmbed(DISCLAIMER_EN)],
     });
   });

--- a/src/slash-commands/insult/index.test.ts
+++ b/src/slash-commands/insult/index.test.ts
@@ -1,29 +1,22 @@
 import { faker } from '@faker-js/faker';
-import type { ChatInputCommandInteraction } from 'discord.js';
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
 import { insult } from '.';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { randomCreate } from './insult-generator';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('Insult someone test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
+  chatInputCommandInteractionTest('Should send an insult when the cmd is sent', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('');
+
+    await insult(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
   });
 
-  it('Should send an insult when the cmd is sent', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('');
+  chatInputCommandInteractionTest('Should insult the chat content', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce(faker.lorem.words(2));
 
-    await insult(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-  });
-
-  it('Should insult the chat content', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce(faker.lorem.words(2));
-
-    await insult(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    await insult(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/slash-commands/mock-someone/index.test.ts
+++ b/src/slash-commands/mock-someone/index.test.ts
@@ -5,7 +5,7 @@ import { mockSomeone } from '.';
 import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
 describe('mockSomeone test', () => {
-  chatInputCommandInteractionTest('Should mock text if it was called by /mock', async ({ interaction, message }) => {
+  chatInputCommandInteractionTest('Should mock text if it was called by /mock', async ({ interaction }) => {
     interaction.options.getString.mockReturnValueOnce(faker.lorem.words(25));
 
     await mockSomeone(interaction);
@@ -14,7 +14,7 @@ describe('mockSomeone test', () => {
 
   describe('For /mock call with blank content', () => {
     describe('Fetching previous message', () => {
-      chatInputCommandInteractionTest('Should reply with error if previous message cannot be retrieved', async ({ interaction, message }) => {
+      chatInputCommandInteractionTest('Should reply with error if previous message cannot be retrieved', async ({ interaction }) => {
         const messageCollection = new Collection<string, Message<true>>();
         interaction.options.getString.mockReturnValueOnce('');
         interaction.channel?.messages.fetch.mockResolvedValueOnce(messageCollection);

--- a/src/slash-commands/mock-someone/index.test.ts
+++ b/src/slash-commands/mock-someone/index.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { mock, mockDeep, mockReset } from 'vitest-mock-extended';
 import { mockSomeone } from '.';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const mockMessage = mock<Message<true>>();
 
 describe('mockSomeone test', () => {

--- a/src/slash-commands/mock-someone/index.test.ts
+++ b/src/slash-commands/mock-someone/index.test.ts
@@ -1,63 +1,51 @@
 import { faker } from '@faker-js/faker';
-import { type ChatInputCommandInteraction, Collection, type Message } from 'discord.js';
-import { describe, expect, it } from 'vitest';
-import { mock, mockDeep, mockReset } from 'vitest-mock-extended';
+import { Collection, type Message } from 'discord.js';
+import { describe, expect } from 'vitest';
 import { mockSomeone } from '.';
-
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-const mockMessage = mock<Message<true>>();
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
 describe('mockSomeone test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockReset(mockMessage);
-  });
+  chatInputCommandInteractionTest('Should mock text if it was called by /mock', async ({ interaction, message }) => {
+    interaction.options.getString.mockReturnValueOnce(faker.lorem.words(25));
 
-  it('Should mock text if it was called by /mock', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce(faker.lorem.words(25));
-
-    await mockSomeone(mockInteraction);
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    await mockSomeone(interaction);
+    expect(interaction.reply).toHaveBeenCalledOnce();
   });
 
   describe('For /mock call with blank content', () => {
     describe('Fetching previous message', () => {
-      beforeEach(() => {
-        mockInteraction.options.getString.mockReturnValueOnce('');
+      chatInputCommandInteractionTest('Should reply with error if previous message cannot be retrieved', async ({ interaction, message }) => {
+        const messageCollection = new Collection<string, Message<true>>();
+        interaction.options.getString.mockReturnValueOnce('');
+        interaction.channel?.messages.fetch.mockResolvedValueOnce(messageCollection);
+
+        await mockSomeone(interaction);
+        expect(interaction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(interaction.reply).toHaveBeenCalledOnce();
+        expect(interaction.reply).toHaveBeenCalledWith('Cannot fetch latest message. Please try again later.');
       });
 
-      it('Should reply with error if previous message cannot be retrieved', async () => {
-        const mockMessageCollection = new Collection<string, Message<true>>();
-        mockInteraction.options.getString.mockReturnValueOnce('');
-        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(mockMessageCollection);
+      chatInputCommandInteractionTest('Should reply with error if previous message is blank', async ({ interaction, message }) => {
+        message.content = '';
+        const messageCollection = new Collection<string, Message<true>>();
+        interaction.options.getString.mockReturnValueOnce('');
+        interaction.channel?.messages.fetch.mockResolvedValueOnce(messageCollection);
 
-        await mockSomeone(mockInteraction);
-        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toHaveBeenCalledWith('Cannot fetch latest message. Please try again later.');
+        await mockSomeone(interaction);
+        expect(interaction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(interaction.reply).toHaveBeenCalledOnce();
+        expect(interaction.reply).toHaveBeenCalledWith('Cannot fetch latest message. Please try again later.');
       });
 
-      it('Should reply with error if previous message is blank', async () => {
-        mockMessage.content = '';
-        const mockMessageCollection = new Collection<string, Message<true>>();
-        mockInteraction.options.getString.mockReturnValueOnce('');
-        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(mockMessageCollection);
+      chatInputCommandInteractionTest('Should mock the previous message', async ({ interaction, message }) => {
+        message.content = faker.lorem.words(25);
+        const messageCollection = new Collection<string, Message<true>>();
+        interaction.options.getString.mockReturnValueOnce('');
+        interaction.channel?.messages.fetch.mockResolvedValueOnce(messageCollection);
 
-        await mockSomeone(mockInteraction);
-        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toHaveBeenCalledWith('Cannot fetch latest message. Please try again later.');
-      });
-
-      it('Should mock the previous message', async () => {
-        mockMessage.content = faker.lorem.words(25);
-        const mockMessageCollection = new Collection<string, Message<true>>();
-        mockInteraction.options.getString.mockReturnValueOnce('');
-        mockInteraction.channel?.messages.fetch.mockResolvedValueOnce(mockMessageCollection);
-
-        await mockSomeone(mockInteraction);
-        expect(mockInteraction.channel?.messages.fetch).toHaveBeenCalledOnce();
-        expect(mockInteraction.reply).toHaveBeenCalledOnce();
+        await mockSomeone(interaction);
+        expect(interaction.channel?.messages.fetch).toHaveBeenCalledOnce();
+        expect(interaction.reply).toHaveBeenCalledOnce();
       });
     });
   });

--- a/src/slash-commands/moderate-users/index.test.ts
+++ b/src/slash-commands/moderate-users/index.test.ts
@@ -1,32 +1,19 @@
-import {
-  type APIRole,
-  type ChatInputCommandInteraction,
-  Collection,
-  type GuildTextBasedChannel,
-  type Role,
-  type ThreadMember,
-  type ThreadMemberManager,
-} from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
+import { type APIRole, Collection, type GuildTextBasedChannel, type Role, type ThreadMember, type ThreadMemberManager } from 'discord.js';
+import { describe, expect } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
 import { removeUserByRole } from '.';
-
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
 describe('Remove users who have the role', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
+  chatInputCommandInteractionTest('should reply with an error message if the command is not executed in a thread', async ({ interaction }) => {
+    interaction.channel?.isThread.mockReturnValueOnce(false);
+
+    await removeUserByRole(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith("You can't remove all users from entire channel. This command only works in a thread.");
   });
 
-  it('should reply with an error message if the command is not executed in a thread', async () => {
-    mockInteraction.channel?.isThread.mockReturnValueOnce(false);
-
-    await removeUserByRole(mockInteraction);
-
-    expect(mockInteraction.reply).toHaveBeenCalledWith("You can't remove all users from entire channel. This command only works in a thread.");
-  });
-
-  it('should remove all users from the thread with the matching role', async () => {
+  chatInputCommandInteractionTest('should remove all users from the thread with the matching role', async ({ interaction }) => {
     const fakeRoles = new Collection<string, Role>();
     fakeRoles.set('1', { id: 'role-id', name: 'name' } as Role);
     const mockMembers = new Collection<string, ThreadMember>();
@@ -55,17 +42,17 @@ describe('Remove users who have the role', () => {
       },
     } as ThreadMember);
 
-    mockInteraction.channel?.isTextBased.mockReturnValueOnce(true);
-    mockInteraction.channel?.isThread.mockReturnValueOnce(true);
-    ((mockInteraction.channel as GuildTextBasedChannel).members as DeepMockProxy<ThreadMemberManager>).fetch.mockResolvedValueOnce(mockMembers);
-    mockInteraction.options.getRole.mockReturnValueOnce({
+    interaction.channel?.isTextBased.mockReturnValueOnce(true);
+    interaction.channel?.isThread.mockReturnValueOnce(true);
+    ((interaction.channel as GuildTextBasedChannel).members as DeepMockProxy<ThreadMemberManager>).fetch.mockResolvedValueOnce(mockMembers);
+    interaction.options.getRole.mockReturnValueOnce({
       id: 'role-id',
       name: 'name',
     } as APIRole);
 
-    await removeUserByRole(mockInteraction);
+    await removeUserByRole(interaction);
 
-    expect(mockInteraction.deferReply).toHaveBeenCalled();
-    expect(mockInteraction.editReply).toHaveBeenCalled();
+    expect(interaction.deferReply).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalled();
   });
 });

--- a/src/slash-commands/moderate-users/index.test.ts
+++ b/src/slash-commands/moderate-users/index.test.ts
@@ -1,9 +1,17 @@
-import { type APIRole, type ChatInputCommandInteraction, Collection, type Role, type ThreadMember, type ThreadMemberManager } from 'discord.js';
+import {
+  type APIRole,
+  type ChatInputCommandInteraction,
+  Collection,
+  type GuildTextBasedChannel,
+  type Role,
+  type ThreadMember,
+  type ThreadMemberManager,
+} from 'discord.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
 import { removeUserByRole } from '.';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction<'raw'>>();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('Remove users who have the role', () => {
   beforeEach(() => {
@@ -49,7 +57,7 @@ describe('Remove users who have the role', () => {
 
     mockInteraction.channel?.isTextBased.mockReturnValueOnce(true);
     mockInteraction.channel?.isThread.mockReturnValueOnce(true);
-    (mockInteraction.channel?.members as DeepMockProxy<ThreadMemberManager>).fetch.mockResolvedValueOnce(mockMembers);
+    ((mockInteraction.channel as GuildTextBasedChannel).members as DeepMockProxy<ThreadMemberManager>).fetch.mockResolvedValueOnce(mockMembers);
     mockInteraction.options.getRole.mockReturnValueOnce({
       id: 'role-id',
       name: 'name',

--- a/src/slash-commands/powerball/index.test.ts
+++ b/src/slash-commands/powerball/index.test.ts
@@ -1,33 +1,27 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect } from 'vitest';
+import { captor } from 'vitest-mock-extended';
 import { powerball } from '.';
-
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 
 describe('powerball', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('should return correct number of games', async () => {
+  chatInputCommandInteractionTest('should return correct number of games', async ({ interaction }) => {
     const gameCount = 5;
-    mockInteraction.options.getInteger.mockReturnValueOnce(gameCount);
+    interaction.options.getInteger.mockReturnValueOnce(gameCount);
     const games = captor<string>();
 
-    await powerball(mockInteraction);
+    await powerball(interaction);
 
-    expect(mockInteraction.reply).toHaveBeenCalledWith(games);
+    expect(interaction.reply).toHaveBeenCalledWith(games);
     expect(games.value.split('\n').length).toEqual(gameCount);
   });
 
-  it('should return 7 unique numbers from 1-35', async () => {
-    mockInteraction.options.getInteger.mockReturnValueOnce(1);
+  chatInputCommandInteractionTest('should return 7 unique numbers from 1-35', async ({ interaction }) => {
+    interaction.options.getInteger.mockReturnValueOnce(1);
     const singleGame = captor<string>();
 
-    await powerball(mockInteraction);
+    await powerball(interaction);
 
-    expect(mockInteraction.reply).toHaveBeenCalledWith(singleGame);
+    expect(interaction.reply).toHaveBeenCalledWith(singleGame);
 
     let gameValue = singleGame.value.replaceAll('`', '');
     gameValue = gameValue.substring(0, gameValue.indexOf('PB')).trim();
@@ -35,24 +29,24 @@ describe('powerball', () => {
     expect(uniqueNumbers.length).toEqual(new Set(uniqueNumbers).size);
   });
 
-  it('should return the correct format', async () => {
-    mockInteraction.options.getInteger.mockReturnValueOnce(10);
+  chatInputCommandInteractionTest('should return the correct format', async ({ interaction }) => {
+    interaction.options.getInteger.mockReturnValueOnce(10);
     const games = captor<string>();
     const regex = /^(\d{2}\s){7}PB:\d{2}$/gm; // Matches multiline of 00 00 00 00 00 00 00 PB:00
 
-    await powerball(mockInteraction);
+    await powerball(interaction);
 
-    expect(mockInteraction.reply).toHaveBeenCalledWith(games);
+    expect(interaction.reply).toHaveBeenCalledWith(games);
     expect(games.value.replaceAll('`', '')).toMatch(regex);
   });
 
-  it('PB numbers from 1 - 20', async () => {
-    mockInteraction.options.getInteger.mockReturnValueOnce(1);
+  chatInputCommandInteractionTest('PB numbers from 1 - 20', async ({ interaction }) => {
+    interaction.options.getInteger.mockReturnValueOnce(1);
     const singleGame = captor<string>();
 
-    await powerball(mockInteraction);
+    await powerball(interaction);
 
-    expect(mockInteraction.reply).toHaveBeenCalledWith(singleGame);
+    expect(interaction.reply).toHaveBeenCalledWith(singleGame);
 
     const gameValue = singleGame.value.replaceAll('`', '');
     const pbNumber = gameValue.substring(gameValue.indexOf(':') + 1);

--- a/src/slash-commands/quote-of-the-day/index.test.ts
+++ b/src/slash-commands/quote-of-the-day/index.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 import { getQuoteOfTheDay } from '.';
 import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { server } from '../../../test/mocks/msw/server';

--- a/src/slash-commands/quote-of-the-day/index.test.ts
+++ b/src/slash-commands/quote-of-the-day/index.test.ts
@@ -1,42 +1,35 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
 import { http, HttpResponse } from 'msw';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, it } from 'vitest';
 import { getQuoteOfTheDay } from '.';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { server } from '../../../test/mocks/msw/server';
 import { ZEN_QUOTES_URL } from './fetch-quote';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('Get quote of the day test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('Should reply with error if it downloaded a blank array', async () => {
+  chatInputCommandInteractionTest('Should reply with error if it downloaded a blank array', async ({ interaction }) => {
     const endpoint = http.get(ZEN_QUOTES_URL, () => {
       return HttpResponse.json([]);
     });
     server.use(endpoint);
 
-    await getQuoteOfTheDay(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith('Error getting quotes');
+    await getQuoteOfTheDay(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    expect(interaction.editReply).toHaveBeenCalledWith('Error getting quotes');
   });
 
-  it('Should reply with error message if it error while downloading quotes', async () => {
+  chatInputCommandInteractionTest('Should reply with error message if it error while downloading quotes', async ({ interaction }) => {
     const endpoint = http.get(ZEN_QUOTES_URL, () => {
       return HttpResponse.error();
     });
     server.use(endpoint);
 
-    await getQuoteOfTheDay(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith('Error getting quotes');
+    await getQuoteOfTheDay(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    expect(interaction.editReply).toHaveBeenCalledWith('Error getting quotes');
   });
 
-  it('Should reply with a random quote', async () => {
-    await getQuoteOfTheDay(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+  chatInputCommandInteractionTest('Should reply with a random quote', async ({ interaction }) => {
+    await getQuoteOfTheDay(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
   });
 });

--- a/src/slash-commands/referral/referral-new.test.ts
+++ b/src/slash-commands/referral/referral-new.test.ts
@@ -1,7 +1,9 @@
 import { addDays } from 'date-fns';
-import type { AutocompleteInteraction, ChatInputCommandInteraction, Guild } from 'discord.js';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
+import type { AutocompleteInteraction, Guild } from 'discord.js';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { captor } from 'vitest-mock-extended';
+import { autocompleteInteractionTest } from '../../../test/fixtures/autocomplete-interaction';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { getOrCreateUser } from '../reputation/utils';
 import { DEFAULT_EXPIRY_DAYS_FROM_NOW, autocomplete, execute } from './referral-new';
 import { services } from './services';
@@ -14,41 +16,34 @@ const mockCreateReferralCode = vi.mocked(createReferralCode);
 vi.mock('../reputation/utils');
 const mockGetOrCreateUser = vi.mocked(getOrCreateUser);
 
-const mockAutocompleteInteraction = mockDeep<AutocompleteInteraction>();
-const mockChatInputInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('autocomplete', () => {
-  beforeEach(() => {
-    mockReset(mockAutocompleteInteraction);
-  });
-
-  it('should return nothing if the search term shorter than 4', async () => {
-    mockAutocompleteInteraction.options.getString.mockReturnValueOnce('solve');
+  autocompleteInteractionTest('should return nothing if the search term shorter than 4', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('solve');
     const respondInput = captor<Parameters<AutocompleteInteraction['respond']>['0']>();
 
-    await autocomplete(mockAutocompleteInteraction);
+    await autocomplete(interaction);
 
-    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
+    expect(interaction.respond).toBeCalledWith(respondInput);
     expect(respondInput.value.length).toEqual(1);
   });
 
-  it('should return nothing if no options found', async () => {
-    mockAutocompleteInteraction.options.getString.mockReturnValueOnce('some random search that not existed');
+  autocompleteInteractionTest('should return nothing if no options found', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('some random search that not existed');
     const respondInput = captor<Parameters<AutocompleteInteraction['respond']>['0']>();
 
-    await autocomplete(mockAutocompleteInteraction);
+    await autocomplete(interaction);
 
-    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
+    expect(interaction.respond).toBeCalledWith(respondInput);
     expect(respondInput.value.length).toEqual(0);
   });
 
-  it('should return some options if search term longer than 4 and found', async () => {
-    mockAutocompleteInteraction.options.getString.mockReturnValueOnce('heal');
+  autocompleteInteractionTest('should return some options if search term longer than 4 and found', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('heal');
     const respondInput = captor<Parameters<AutocompleteInteraction['respond']>['0']>();
 
-    await autocomplete(mockAutocompleteInteraction);
+    await autocomplete(interaction);
 
-    expect(mockAutocompleteInteraction.respond).toBeCalledWith(respondInput);
+    expect(interaction.respond).toBeCalledWith(respondInput);
     expect(respondInput.value).toMatchInlineSnapshot(`
       [
         {
@@ -86,7 +81,6 @@ describe('autocomplete', () => {
 
 describe('execute', () => {
   beforeEach(() => {
-    mockReset(mockChatInputInteraction);
     vi.useFakeTimers();
     const date = new Date();
     vi.setSystemTime(date);
@@ -96,9 +90,9 @@ describe('execute', () => {
     vi.useRealTimers();
   });
 
-  it('should return no service error if service is not in services list', async () => {
+  chatInputCommandInteractionTest('should return no service error if service is not in services list', async ({ interaction }) => {
     const service = 'not in the list';
-    mockChatInputInteraction.options.getString.mockImplementation((name, required) => {
+    interaction.options.getString.mockImplementation((name, required) => {
       if (name === 'service') return service;
       if (name === 'link_or_code') return null;
       if (name === 'expiry_date' && required) return 'lol';
@@ -106,13 +100,13 @@ describe('execute', () => {
       return null;
     });
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
-    expect(mockChatInputInteraction.reply).toBeCalledWith(`No service named ${service}, ask the admin to add it`);
+    expect(interaction.reply).toBeCalledWith(`No service named ${service}, ask the admin to add it`);
   });
 
-  it('should return INVALID_DATE error when provide invalid expiry date format', async () => {
-    mockChatInputInteraction.options.getString.mockImplementation((name, required) => {
+  chatInputCommandInteractionTest('should return INVALID_DATE error when provide invalid expiry date format', async ({ interaction }) => {
+    interaction.options.getString.mockImplementation((name) => {
       if (name === 'service') return services[0];
       if (name === 'link_or_code') return null;
       if (name === 'expiry_date') return 'lol';
@@ -120,26 +114,26 @@ describe('execute', () => {
       return null;
     });
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
-    expect(mockChatInputInteraction.reply).toBeCalledWith('expiry_date is invalid date try format DD/MM/YYYY');
+    expect(interaction.reply).toBeCalledWith('expiry_date is invalid date try format DD/MM/YYYY');
   });
 
-  it('should return EXPIRED_DATE error when expiry date is in the past', async () => {
+  chatInputCommandInteractionTest('should return EXPIRED_DATE error when expiry date is in the past', async ({ interaction }) => {
     const input: Record<string, string | null> = {
       service: services[0],
       link_or_code: null,
       expiry_date: `04/04/${new Date().getFullYear() - 10}`,
     };
 
-    mockChatInputInteraction.options.getString.mockImplementation((name: string) => input[name]);
+    interaction.options.getString.mockImplementation((name: string) => input[name]);
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
-    expect(mockChatInputInteraction.reply).toBeCalledWith('expiry_date has already expired');
+    expect(interaction.reply).toBeCalledWith('expiry_date has already expired');
   });
 
-  it('should block adding referral code if the user already has one', async () => {
+  chatInputCommandInteractionTest('should block adding referral code if the user already has one', async ({ interaction }) => {
     const data = {
       service: services[0],
       code: 'SomeCodeHere',
@@ -158,8 +152,8 @@ describe('execute', () => {
     });
     mockGetOrCreateUser.mockResolvedValueOnce({ id: data.userId, reputation: 0 });
 
-    mockChatInputInteraction.user.id = data.userId;
-    mockChatInputInteraction.options.getString.mockImplementation((name: string, required?: boolean) => {
+    interaction.user.id = data.userId;
+    interaction.options.getString.mockImplementation((name: string) => {
       if (name === 'service') return data.service;
       if (name === 'link_or_code') return data.code;
       if (name === 'expiry_date') return data.expiry_date;
@@ -167,12 +161,12 @@ describe('execute', () => {
       return null;
     });
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
-    expect(mockChatInputInteraction.reply).toBeCalledWith(`You have already entered the referral code for ${services[0]}.`);
+    expect(interaction.reply).toBeCalledWith(`You have already entered the referral code for ${services[0]}.`);
   });
 
-  it('should create a new referral code', async () => {
+  chatInputCommandInteractionTest('should create a new referral code', async ({ interaction }) => {
     const data = {
       service: services[0],
       code: 'SomeCodeHere',
@@ -193,9 +187,9 @@ describe('execute', () => {
     });
     mockGetOrCreateUser.mockResolvedValueOnce({ id: data.userId, reputation: 0 });
 
-    mockChatInputInteraction.user.id = data.userId;
-    (mockChatInputInteraction.guild as Guild).id = data.guildId;
-    mockChatInputInteraction.options.getString.mockImplementation((name: string, required?: boolean) => {
+    interaction.user.id = data.userId;
+    (interaction.guild as Guild).id = data.guildId;
+    interaction.options.getString.mockImplementation((name: string) => {
       if (name === 'service') return data.service;
       if (name === 'link_or_code') return data.code;
       if (name === 'expiry_date') return data.expiry_date;
@@ -204,7 +198,7 @@ describe('execute', () => {
     });
     const replyInput = captor<string>();
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
     expect(mockCreateReferralCode).toBeCalledWith(mockReferralInput);
     const input = mockReferralInput.value;
@@ -212,50 +206,53 @@ describe('execute', () => {
     expect(input.code).toBe(data.code);
     expect(input.expiryDate.toISOString()).toBe(new Date(data.expiry_date).toISOString());
 
-    expect(mockChatInputInteraction.reply).toBeCalledWith(replyInput);
+    expect(interaction.reply).toBeCalledWith(replyInput);
     expect(replyInput.value).toContain(`just added referral code SomeCodeHere in ${services[0]}`);
   });
 
-  it(`should create a new referral code in ${DEFAULT_EXPIRY_DAYS_FROM_NOW} days from now when not given the expiry date`, async () => {
-    const data = {
-      service: services[0],
-      code: 'SomeCodeHere',
-      userId: '1234',
-      guildId: '12345',
-      expiry_date: addDays(new Date(), DEFAULT_EXPIRY_DAYS_FROM_NOW),
-    };
+  chatInputCommandInteractionTest(
+    `should create a new referral code in ${DEFAULT_EXPIRY_DAYS_FROM_NOW} days from now when not given the expiry date`,
+    async ({ interaction }) => {
+      const data = {
+        service: services[0],
+        code: 'SomeCodeHere',
+        userId: '1234',
+        guildId: '12345',
+        expiry_date: addDays(new Date(), DEFAULT_EXPIRY_DAYS_FROM_NOW),
+      };
 
-    const mockReferralInput = captor<CreateReferralInput>();
-    mockFindExistingReferralCode.mockResolvedValueOnce(null);
-    mockCreateReferralCode.mockResolvedValueOnce({
-      id: '12345',
-      service: data.service,
-      code: data.code,
-      expiry_date: data.expiry_date,
-      userId: data.userId,
-      guildId: data.guildId,
-    });
+      const mockReferralInput = captor<CreateReferralInput>();
+      mockFindExistingReferralCode.mockResolvedValueOnce(null);
+      mockCreateReferralCode.mockResolvedValueOnce({
+        id: '12345',
+        service: data.service,
+        code: data.code,
+        expiry_date: data.expiry_date,
+        userId: data.userId,
+        guildId: data.guildId,
+      });
 
-    mockChatInputInteraction.user.id = data.userId;
-    (mockChatInputInteraction.guild as Guild).id = data.guildId;
-    mockChatInputInteraction.options.getString.mockImplementation((name: string, required?: boolean) => {
-      if (name === 'service') return data.service;
-      if (name === 'link_or_code') return data.code;
-      if (name === 'expiry_date') return null;
+      interaction.user.id = data.userId;
+      (interaction.guild as Guild).id = data.guildId;
+      interaction.options.getString.mockImplementation((name: string) => {
+        if (name === 'service') return data.service;
+        if (name === 'link_or_code') return data.code;
+        if (name === 'expiry_date') return null;
 
-      return null;
-    });
-    const replyInput = captor<string>();
+        return null;
+      });
+      const replyInput = captor<string>();
 
-    await execute(mockChatInputInteraction);
+      await execute(interaction);
 
-    expect(mockCreateReferralCode).toBeCalledWith(mockReferralInput);
-    const input = mockReferralInput.value;
-    expect(input.service).toBe(data.service);
-    expect(input.code).toBe(data.code);
-    expect(input.expiryDate.toISOString()).toBe(new Date(data.expiry_date).toISOString());
+      expect(mockCreateReferralCode).toBeCalledWith(mockReferralInput);
+      const input = mockReferralInput.value;
+      expect(input.service).toBe(data.service);
+      expect(input.code).toBe(data.code);
+      expect(input.expiryDate.toISOString()).toBe(new Date(data.expiry_date).toISOString());
 
-    expect(mockChatInputInteraction.reply).toBeCalledWith(replyInput);
-    expect(replyInput.value).toContain(`just added referral code SomeCodeHere in ${services[0]}`);
-  });
+      expect(interaction.reply).toBeCalledWith(replyInput);
+      expect(replyInput.value).toContain(`just added referral code SomeCodeHere in ${services[0]}`);
+    }
+  );
 });

--- a/src/slash-commands/referral/referral-new.test.ts
+++ b/src/slash-commands/referral/referral-new.test.ts
@@ -1,6 +1,6 @@
 import { addDays } from 'date-fns';
 import type { AutocompleteInteraction, ChatInputCommandInteraction, Guild } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
 import { getOrCreateUser } from '../reputation/utils';
 import { DEFAULT_EXPIRY_DAYS_FROM_NOW, autocomplete, execute } from './referral-new';

--- a/src/slash-commands/referral/referral-new.test.ts
+++ b/src/slash-commands/referral/referral-new.test.ts
@@ -116,7 +116,7 @@ describe('execute', () => {
 
     await execute(interaction);
 
-    expect(interaction.reply).toBeCalledWith('expiry_date is invalid date try format DD/MM/YYYY');
+    expect(interaction.reply).toBeCalledWith('expiry_date is an invalid date. Please use the format DD/MM/YYYY.');
   });
 
   chatInputCommandInteractionTest('should return EXPIRED_DATE error when expiry date is in the past', async ({ interaction }) => {

--- a/src/slash-commands/referral/referral-new.ts
+++ b/src/slash-commands/referral/referral-new.ts
@@ -50,7 +50,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
 
     if (parseDateCase === 'INVALID_DATE') {
       logger.info(`[referral-new]: expiry_date is invalid date format input:${expiryDateInput}`);
-      await interaction.reply('expiry_date is invalid date try format DD/MM/YYYY');
+      await interaction.reply('expiry_date is an invalid date. Please use the format DD/MM/YYYY.');
       return;
     }
     if (parseDateCase === 'EXPIRED_DATE') {

--- a/src/slash-commands/reminder/remind-on-date.test.ts
+++ b/src/slash-commands/reminder/remind-on-date.test.ts
@@ -1,14 +1,12 @@
 import { getYear } from 'date-fns';
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { convertDateToEpoch } from '../../utils/date';
 import { execute } from './remind-on-date';
 import { saveReminder } from './utils';
 
 vi.mock('./utils');
 const mockSaveReminder = vi.mocked(saveReminder);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 const dateString = `31/12/${getYear(new Date())} 00:00`;
 const message = 'blah';
@@ -30,24 +28,23 @@ const mockGetString = (param: string) => {
 };
 
 describe('remind on date', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockInteraction.guildId = guildId;
-    mockInteraction.member!.user.id = userId;
-    mockInteraction.options.getString.mockImplementation(mockGetString);
-  });
-
-  it('should send error reply if it cannot save reminder', async () => {
+  chatInputCommandInteractionTest('should send error reply if it cannot save reminder', async ({ interaction }) => {
+    interaction.guildId = guildId;
+    interaction.member!.user.id = userId;
+    interaction.options.getString.mockImplementation(mockGetString);
     mockSaveReminder.mockRejectedValueOnce(new Error('Synthetic Error'));
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockSaveReminder).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`Cannot save reminder for <@${userId}>. Please try again later.`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`Cannot save reminder for <@${userId}>. Please try again later.`);
   });
 
-  it('should send reply if it can save reminder', async () => {
+  chatInputCommandInteractionTest('should send reply if it can save reminder', async ({ interaction }) => {
+    interaction.guildId = guildId;
+    interaction.member!.user.id = userId;
+    interaction.options.getString.mockImplementation(mockGetString);
     const unixTime = convertDateToEpoch(dateString);
     mockSaveReminder.mockResolvedValueOnce({
       id: reminderId,
@@ -57,10 +54,10 @@ describe('remind on date', () => {
       message,
     });
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockSaveReminder).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`New Reminder for <@${userId}> set on <t:${unixTime}> with the message: "${message}".`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`New Reminder for <@${userId}> set on <t:${unixTime}> with the message: "${message}".`);
   });
 });

--- a/src/slash-commands/reminder/remove.test.ts
+++ b/src/slash-commands/reminder/remove.test.ts
@@ -1,38 +1,33 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { execute } from './remove';
 import { removeReminder } from './utils';
 
 vi.mock('./utils');
 const mockRemoveReminder = vi.mocked(removeReminder);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 const reminderId = '1';
 
 describe('Remove Reminder', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockInteraction.options.getString.mockReturnValueOnce(reminderId);
-  });
-
-  it('Should reply with error if reminders cannot be removed', async () => {
+  chatInputCommandInteractionTest('Should reply with error if reminders cannot be removed', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce(reminderId);
     mockRemoveReminder.mockRejectedValueOnce(new Error('Synthetic error'));
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockRemoveReminder).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`Cannot delete reminder id ${reminderId}. Please try again later.`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`Cannot delete reminder id ${reminderId}. Please try again later.`);
   });
 
-  it('Should reply if reminder can be removed', async () => {
+  chatInputCommandInteractionTest('Should reply if reminder can be removed', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce(reminderId);
     mockRemoveReminder.mockResolvedValueOnce();
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockRemoveReminder).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`Reminder ${reminderId} has been deleted.`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`Reminder ${reminderId} has been deleted.`);
   });
 });

--- a/src/slash-commands/reminder/update.test.ts
+++ b/src/slash-commands/reminder/update.test.ts
@@ -1,14 +1,12 @@
 import { getYear } from 'date-fns';
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { convertDateToEpoch } from '../../utils/date';
 import { execute } from './update';
 import { updateReminder } from './utils';
 
 vi.mock('./utils');
 const mockUpdateReminder = vi.mocked(updateReminder);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 const dateString = `31/12/${getYear(new Date())} 00:00`;
 const message = 'blah';
@@ -31,36 +29,36 @@ const mockGetString = (param: string, _required?: boolean) => {
 };
 
 describe('update reminder', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-    mockInteraction.guildId = guildId;
-    mockInteraction.member!.user.id = userId;
-  });
-
-  it("Should send error reply if there's nothing to update", async () => {
-    mockInteraction.options.getString.mockImplementation((param: string) => {
+  chatInputCommandInteractionTest("Should send error reply if there's nothing to update", async ({ interaction }) => {
+    interaction.guildId = guildId;
+    interaction.member!.user.id = userId;
+    interaction.options.getString.mockImplementation((param: string) => {
       return param === 'id' ? reminderId : null;
     });
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockUpdateReminder).not.toHaveBeenCalled();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('Nothing to update. Skipping...');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Nothing to update. Skipping...');
   });
 
-  it('Should send error reply if it cannot update reminder', async () => {
+  chatInputCommandInteractionTest('Should send error reply if it cannot update reminder', async ({ interaction }) => {
+    interaction.guildId = guildId;
+    interaction.member!.user.id = userId;
     mockUpdateReminder.mockRejectedValueOnce(new Error('Synthetic Error'));
-    mockInteraction.options.getString.mockImplementation(mockGetString);
+    interaction.options.getString.mockImplementation(mockGetString);
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockUpdateReminder).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`Cannot update reminder for <@${userId}> and reminder id ${reminderId}. Please try again later.`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`Cannot update reminder for <@${userId}> and reminder id ${reminderId}. Please try again later.`);
   });
 
-  it('Should send reply with default timezone if no timezone given', async () => {
+  chatInputCommandInteractionTest('Should send reply with default timezone if no timezone given', async ({ interaction }) => {
+    interaction.guildId = guildId;
+    interaction.member!.user.id = userId;
     const unixTimestamp = convertDateToEpoch(dateString);
     mockUpdateReminder.mockResolvedValueOnce({
       id: reminderId,
@@ -69,14 +67,12 @@ describe('update reminder', () => {
       onTimestamp: unixTimestamp,
       message,
     });
-    mockInteraction.options.getString.mockImplementation(mockGetString);
+    interaction.options.getString.mockImplementation(mockGetString);
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockUpdateReminder).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
-      `Reminder ${reminderId} has been updated to remind on <t:${unixTimestamp}> with the message: "${message}".`
-    );
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`Reminder ${reminderId} has been updated to remind on <t:${unixTimestamp}> with the message: "${message}".`);
   });
 });

--- a/src/slash-commands/reputation/check-reputation.test.ts
+++ b/src/slash-commands/reputation/check-reputation.test.ts
@@ -1,28 +1,22 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { checkReputation } from './check-reputation';
 import { getOrCreateUser } from './utils';
 
 vi.mock('./utils');
 const mockGetOrCreateUser = vi.mocked(getOrCreateUser);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('checkReputation', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('should send reply if message is "-rep"', async () => {
+  chatInputCommandInteractionTest('should send reply if message is "-rep"', async ({ interaction }) => {
     mockGetOrCreateUser.mockResolvedValueOnce({
       id: '1',
       reputation: 0,
     });
-    mockInteraction.member!.user.id = '1';
+    interaction.member!.user.id = '1';
 
-    await checkReputation(mockInteraction);
+    await checkReputation(interaction);
 
     expect(mockGetOrCreateUser).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledOnce();
   });
 });

--- a/src/slash-commands/reputation/give-reputation.test.ts
+++ b/src/slash-commands/reputation/give-reputation.test.ts
@@ -1,6 +1,6 @@
-import { type ChatInputCommandInteraction, Collection, type Message, type User } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { Collection, type User } from 'discord.js';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { giveRepSlashCommand, thankUserInMessage } from './give-reputation';
 import { getOrCreateUser, updateRep } from './utils';
 
@@ -8,84 +8,91 @@ vi.mock('./utils');
 const mockCreateUpdateUser = vi.mocked(getOrCreateUser);
 const mockUpdateRep = vi.mocked(updateRep);
 
-const mockMessage = mockDeep<Message<true>>();
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('Thank user in a message', () => {
-  beforeEach(() => {
-    mockReset(mockMessage);
-    mockMessage.content = 'thank';
-    mockMessage.author.id = '0';
-    mockMessage.author.bot = false;
-  });
+  chatInputCommandInteractionTest('should do nothing if bot is saying the keywords', async ({ message }) => {
+    message.content = 'thank';
+    message.author.id = '0';
+    message.author.bot = true;
 
-  it('should do nothing if bot is saying the keywords', async () => {
-    mockMessage.author.bot = true;
-
-    await thankUserInMessage(mockMessage);
+    await thankUserInMessage(message);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(mockMessage.reply).not.toHaveBeenCalled();
+    expect(message.reply).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if user mention no one', async () => {
+  chatInputCommandInteractionTest('should do nothing if user mention no one', async ({ message }) => {
+    message.content = 'thank';
+    message.author.id = '0';
+    message.author.bot = false;
     const mockUsers = new Collection<string, User>();
-    mockMessage.mentions.users = mockUsers as typeof mockMessage.mentions.users;
+    message.mentions.users = mockUsers as typeof message.mentions.users;
 
-    await thankUserInMessage(mockMessage);
+    await thankUserInMessage(message);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(mockMessage.reply).not.toHaveBeenCalled();
+    expect(message.reply).not.toHaveBeenCalled();
   });
 
-  it('should do nothing if only bot is mentioned', async () => {
+  chatInputCommandInteractionTest('should do nothing if only bot is mentioned', async ({ message }) => {
+    message.content = 'thank';
+    message.author.id = '0';
+    message.author.bot = false;
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '1', bot: true } as User);
-    mockMessage.mentions.users = mockUsers as typeof mockMessage.mentions.users;
+    message.mentions.users = mockUsers as typeof message.mentions.users;
 
-    await thankUserInMessage(mockMessage);
+    await thankUserInMessage(message);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(mockMessage.reply).not.toHaveBeenCalled();
+    expect(message.reply).not.toHaveBeenCalled();
   });
 
-  it('should do nothing message if user mention themself', async () => {
+  chatInputCommandInteractionTest('should do nothing message if user mention themself', async ({ message }) => {
+    message.content = 'thank';
+    message.author.id = '0';
+    message.author.bot = false;
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '0' } as User);
-    mockMessage.mentions.users = mockUsers as typeof mockMessage.mentions.users;
+    message.mentions.users = mockUsers as typeof message.mentions.users;
 
-    await thankUserInMessage(mockMessage);
+    await thankUserInMessage(message);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(mockMessage.reply).not.toHaveBeenCalled();
+    expect(message.reply).not.toHaveBeenCalled();
   });
 
-  it('should call reply and add rep if user mention another user', async () => {
+  chatInputCommandInteractionTest('should call reply and add rep if user mention another user', async ({ message }) => {
+    message.content = 'thank';
+    message.author.id = '0';
+    message.author.bot = false;
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '1' } as User);
-    mockMessage.mentions.users = mockUsers as typeof mockMessage.mentions.users;
+    message.mentions.users = mockUsers as typeof message.mentions.users;
     mockCreateUpdateUser.mockResolvedValueOnce({ id: '1', reputation: 0 }).mockResolvedValueOnce({ id: '2', reputation: 0 });
     mockUpdateRep.mockResolvedValueOnce({ id: '1', reputation: 1 });
 
-    await thankUserInMessage(mockMessage);
+    await thankUserInMessage(message);
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledOnce();
-    expect(mockMessage.reply).not.toHaveBeenCalled();
-    expect(mockMessage.channel.send).toHaveBeenCalledOnce();
+    expect(message.reply).not.toHaveBeenCalled();
+    expect(message.channel.send).toHaveBeenCalledOnce();
   });
 
-  it('should give rep multiple times if mentions more than one user', async () => {
+  chatInputCommandInteractionTest('should give rep multiple times if mentions more than one user', async ({ message }) => {
+    message.content = 'thank';
+    message.author.id = '0';
+    message.author.bot = false;
     const mockUsers = new Collection<string, User>();
     mockUsers.set('0', { id: '0', bot: false } as User);
     mockUsers.set('1', { id: '1', bot: true } as User);
     mockUsers.set('2', { id: '2', bot: false } as User);
     mockUsers.set('3', { id: '3', bot: false } as User);
-    mockMessage.mentions.users = mockUsers as typeof mockMessage.mentions.users;
+    message.mentions.users = mockUsers as typeof message.mentions.users;
     mockCreateUpdateUser
       .mockResolvedValueOnce({ id: '0', reputation: 0 })
       .mockResolvedValueOnce({ id: '2', reputation: 0 })
@@ -93,49 +100,45 @@ describe('Thank user in a message', () => {
       .mockResolvedValueOnce({ id: '3', reputation: 0 });
     mockUpdateRep.mockResolvedValueOnce({ id: '2', reputation: 0 }).mockResolvedValueOnce({ id: '3', reputation: 0 });
 
-    await thankUserInMessage(mockMessage);
+    await thankUserInMessage(message);
 
-    expect(mockMessage.channel.send).toHaveBeenCalledOnce();
+    expect(message.channel.send).toHaveBeenCalledOnce();
   });
 });
 
 describe('Give rep slash command', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
+  chatInputCommandInteractionTest('should send reject message if user mention themself', async ({ interaction }) => {
+    interaction.options.getUser.mockReturnValueOnce({ id: '0' } as User);
+    interaction.member!.user.id = '0';
+
+    await giveRepSlashCommand(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('You cannot give rep to a bot or yourself');
   });
 
-  it('should send reject message if user mention themself', async () => {
-    mockInteraction.options.getUser.mockReturnValueOnce({ id: '0' } as User);
-    mockInteraction.member!.user.id = '0';
-
-    await giveRepSlashCommand(mockInteraction);
-
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('You cannot give rep to a bot or yourself');
-  });
-
-  it('should send reject message if user mention a bot', async () => {
+  chatInputCommandInteractionTest('should send reject message if user mention a bot', async ({ interaction }) => {
     const mockUser = { id: '1', bot: true } as User;
-    mockInteraction.options.getUser.mockReturnValueOnce(mockUser);
+    interaction.options.getUser.mockReturnValueOnce(mockUser);
 
-    await giveRepSlashCommand(mockInteraction);
+    await giveRepSlashCommand(interaction);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('You cannot give rep to a bot or yourself');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('You cannot give rep to a bot or yourself');
   });
 
-  it('should call reply and add rep if user mention another user', async () => {
+  chatInputCommandInteractionTest('should call reply and add rep if user mention another user', async ({ interaction }) => {
     const mockUser = { id: '1' } as User;
     mockCreateUpdateUser.mockResolvedValueOnce({ id: '0', reputation: 0 }).mockResolvedValueOnce({ id: '1', reputation: 0 });
     mockUpdateRep.mockResolvedValueOnce({ id: '1', reputation: 1 });
-    mockInteraction.options.getUser.mockReturnValueOnce(mockUser);
+    interaction.options.getUser.mockReturnValueOnce(mockUser);
 
-    await giveRepSlashCommand(mockInteraction);
+    await giveRepSlashCommand(interaction);
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledOnce();
   });
 });

--- a/src/slash-commands/reputation/leaderboard.test.ts
+++ b/src/slash-commands/reputation/leaderboard.test.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker';
 import { type ChatInputCommandInteraction, Collection, type GuildMember } from 'discord.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep, mockReset } from 'vitest-mock-extended';
@@ -8,7 +7,7 @@ import { getRepLeaderboard } from './utils';
 vi.mock('./utils');
 const mockGetRepLeaderboard = vi.mocked(getRepLeaderboard);
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction<'cached'>>();
+const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 
 describe('leaderboard', () => {
   beforeEach(() => {
@@ -35,7 +34,7 @@ describe('leaderboard', () => {
     ]);
     const mockMembers = new Collection<string, GuildMember>();
     mockMembers.set(userid, { nickname: 'sam', displayName: 'sammy' } as GuildMember);
-    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
     await getLeaderboardCommand(mockInteraction);
 
@@ -59,7 +58,7 @@ describe('leaderboard', () => {
     ]);
     const mockMembers = new Collection<string, GuildMember>();
     mockMembers.set(userid, { nickname: null, displayName: 'sammy' } as GuildMember);
-    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
     await getLeaderboardCommand(mockInteraction);
 
@@ -82,7 +81,7 @@ describe('leaderboard', () => {
       },
     ]);
     const mockMembers = new Collection<string, GuildMember>();
-    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
     await getLeaderboardCommand(mockInteraction);
 
@@ -114,7 +113,7 @@ describe('leaderboard', () => {
     const mockMembers = new Collection<string, GuildMember>();
     mockMembers.set('1', { nickname: 'sam' } as GuildMember);
     mockMembers.set('2', { nickname: null, displayName: 'sam2' } as GuildMember);
-    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
     await getLeaderboardCommand(mockInteraction);
 
@@ -159,7 +158,7 @@ describe('leaderboard', () => {
     mockMembers.set('1', { nickname: 'sam' } as GuildMember);
     mockMembers.set('2', { nickname: 'sam2' } as GuildMember);
     mockMembers.set('3', { nickname: 'sam3' } as GuildMember);
-    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
     await getLeaderboardCommand(mockInteraction);
 
@@ -186,7 +185,7 @@ describe('leaderboard', () => {
       });
     }
     mockGetRepLeaderboard.mockResolvedValueOnce(mockRepLeaderboard);
-    mockInteraction.guild.members.fetch.mockResolvedValueOnce(mockMembers);
+    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
     await getLeaderboardCommand(mockInteraction);
 

--- a/src/slash-commands/reputation/leaderboard.test.ts
+++ b/src/slash-commands/reputation/leaderboard.test.ts
@@ -1,30 +1,24 @@
-import { type ChatInputCommandInteraction, Collection, type GuildMember } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { Collection, type GuildMember } from 'discord.js';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { DEFAULT_LEADERBOARD, MAX_LEADERBOARD, getLeaderboard as getLeaderboardCommand } from './leaderboard';
 import { getRepLeaderboard } from './utils';
 
 vi.mock('./utils');
 const mockGetRepLeaderboard = vi.mocked(getRepLeaderboard);
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('leaderboard', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('Should send reply error if it cannot retrieve the rep leaderboard', async () => {
+  chatInputCommandInteractionTest('Should send reply error if it cannot retrieve the rep leaderboard', async ({ interaction }) => {
     mockGetRepLeaderboard.mockResolvedValueOnce([]);
 
-    await getLeaderboardCommand(mockInteraction);
+    await getLeaderboardCommand(interaction);
 
     expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('No one has rep to be on the leaderboard, yet.');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('No one has rep to be on the leaderboard, yet.');
   });
 
-  it('Should create a leaderboard entry with nickname if it can be fetched', async () => {
+  chatInputCommandInteractionTest('Should create a leaderboard entry with nickname if it can be fetched', async ({ interaction }) => {
     const userid = '1';
     mockGetRepLeaderboard.mockResolvedValueOnce([
       {
@@ -34,13 +28,13 @@ describe('leaderboard', () => {
     ]);
     const mockMembers = new Collection<string, GuildMember>();
     mockMembers.set(userid, { nickname: 'sam', displayName: 'sammy' } as GuildMember);
-    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
+    interaction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
-    await getLeaderboardCommand(mockInteraction);
+    await getLeaderboardCommand(interaction);
 
     expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `\`\`\`
  # username rep
  1      sam   0
@@ -48,31 +42,34 @@ describe('leaderboard', () => {
     );
   });
 
-  it('Should create a leaderboard entry with displayName if it can be fetched and nickname cannot be fetched', async () => {
-    const userid = '1';
-    mockGetRepLeaderboard.mockResolvedValueOnce([
-      {
-        id: userid,
-        reputation: 0,
-      },
-    ]);
-    const mockMembers = new Collection<string, GuildMember>();
-    mockMembers.set(userid, { nickname: null, displayName: 'sammy' } as GuildMember);
-    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
+  chatInputCommandInteractionTest(
+    'Should create a leaderboard entry with displayName if it can be fetched and nickname cannot be fetched',
+    async ({ interaction }) => {
+      const userid = '1';
+      mockGetRepLeaderboard.mockResolvedValueOnce([
+        {
+          id: userid,
+          reputation: 0,
+        },
+      ]);
+      const mockMembers = new Collection<string, GuildMember>();
+      mockMembers.set(userid, { nickname: null, displayName: 'sammy' } as GuildMember);
+      interaction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
-    await getLeaderboardCommand(mockInteraction);
+      await getLeaderboardCommand(interaction);
 
-    expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
-      `\`\`\`
+      expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
+      expect(interaction.reply).toHaveBeenCalledOnce();
+      expect(interaction.reply).toHaveBeenCalledWith(
+        `\`\`\`
  # username rep
  1    sammy   0
 \`\`\``
-    );
-  });
+      );
+    }
+  );
 
-  it('Should create a leaderboard entry with userid if it cannot retrieve the member', async () => {
+  chatInputCommandInteractionTest('Should create a leaderboard entry with userid if it cannot retrieve the member', async ({ interaction }) => {
     const userid = '1';
     mockGetRepLeaderboard.mockResolvedValueOnce([
       {
@@ -81,13 +78,13 @@ describe('leaderboard', () => {
       },
     ]);
     const mockMembers = new Collection<string, GuildMember>();
-    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
+    interaction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
-    await getLeaderboardCommand(mockInteraction);
+    await getLeaderboardCommand(interaction);
 
     expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `\`\`\`
  # username rep
  1        1   0
@@ -95,7 +92,7 @@ describe('leaderboard', () => {
     );
   });
 
-  it('Should send reply with leaderboard with more than 1 record in correct order', async () => {
+  chatInputCommandInteractionTest('Should send reply with leaderboard with more than 1 record in correct order', async ({ interaction }) => {
     mockGetRepLeaderboard.mockResolvedValueOnce([
       {
         id: '3',
@@ -113,13 +110,13 @@ describe('leaderboard', () => {
     const mockMembers = new Collection<string, GuildMember>();
     mockMembers.set('1', { nickname: 'sam' } as GuildMember);
     mockMembers.set('2', { nickname: null, displayName: 'sam2' } as GuildMember);
-    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
+    interaction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
-    await getLeaderboardCommand(mockInteraction);
+    await getLeaderboardCommand(interaction);
 
     expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `\`\`\`
  # username rep
  1        3   3
@@ -129,17 +126,17 @@ describe('leaderboard', () => {
     );
   });
 
-  it(`should reject if it goes over MAX of ${MAX_LEADERBOARD}`, () => {
-    mockInteraction.options.getNumber.mockReturnValueOnce(MAX_LEADERBOARD + 1);
+  chatInputCommandInteractionTest(`should reject if it goes over MAX of ${MAX_LEADERBOARD}`, async ({ interaction }) => {
+    interaction.options.getNumber.mockReturnValueOnce(MAX_LEADERBOARD + 1);
 
-    getLeaderboardCommand(mockInteraction);
+    getLeaderboardCommand(interaction);
 
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`The size is too big. Max is ${MAX_LEADERBOARD}`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`The size is too big. Max is ${MAX_LEADERBOARD}`);
   });
 
-  it('Should send reply with leaderboard with provided number', async () => {
-    mockInteraction.options.getNumber.mockReturnValueOnce(3);
+  chatInputCommandInteractionTest('Should send reply with leaderboard with provided number', async ({ interaction }) => {
+    interaction.options.getNumber.mockReturnValueOnce(3);
     mockGetRepLeaderboard.mockResolvedValueOnce([
       {
         id: '3',
@@ -158,13 +155,13 @@ describe('leaderboard', () => {
     mockMembers.set('1', { nickname: 'sam' } as GuildMember);
     mockMembers.set('2', { nickname: 'sam2' } as GuildMember);
     mockMembers.set('3', { nickname: 'sam3' } as GuildMember);
-    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
+    interaction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
-    await getLeaderboardCommand(mockInteraction);
+    await getLeaderboardCommand(interaction);
 
     expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `\`\`\`
  # username rep
  1     sam3   3
@@ -174,7 +171,7 @@ describe('leaderboard', () => {
     );
   });
 
-  it(`should send reply leaderboard with a default of ${DEFAULT_LEADERBOARD}`, async () => {
+  chatInputCommandInteractionTest(`should send reply leaderboard with a default of ${DEFAULT_LEADERBOARD}`, async ({ interaction }) => {
     const mockRepLeaderboard: Awaited<ReturnType<typeof getRepLeaderboard>> = [];
     const mockMembers = new Collection<string, GuildMember>();
     for (let i = DEFAULT_LEADERBOARD; i >= 1; i--) {
@@ -185,13 +182,13 @@ describe('leaderboard', () => {
       });
     }
     mockGetRepLeaderboard.mockResolvedValueOnce(mockRepLeaderboard);
-    mockInteraction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
+    interaction.guild!.members.fetch.mockResolvedValueOnce(mockMembers);
 
-    await getLeaderboardCommand(mockInteraction);
+    await getLeaderboardCommand(interaction);
 
     expect(mockGetRepLeaderboard).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(
       `\`\`\`
  # username rep
  1    sam10  10

--- a/src/slash-commands/reputation/set-reputation.test.ts
+++ b/src/slash-commands/reputation/set-reputation.test.ts
@@ -1,6 +1,6 @@
-import type { ChatInputCommandInteraction, GuildMember, User } from 'discord.js';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import type { GuildMember, User } from 'discord.js';
+import { beforeAll, describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { isAdmin } from '../../utils/permission';
 import { setReputation } from './set-reputation';
 import { getOrCreateUser, updateRep } from './utils';
@@ -12,44 +12,38 @@ const mockUpdateRep = vi.mocked(updateRep);
 vi.mock('../../utils/permission');
 const mockIsSentFromAdmin = vi.mocked(isAdmin);
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('setRep', () => {
   beforeAll(() => {
     mockIsSentFromAdmin.mockReturnValue(true);
   });
 
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('should reply with an error message if the user is not an admin', async () => {
+  chatInputCommandInteractionTest('should reply with an error message if the user is not an admin', async ({ interaction }) => {
     mockIsSentFromAdmin.mockReturnValueOnce(false);
 
-    await setReputation(mockInteraction);
+    await setReputation(interaction);
 
     expect(mockCreateUpdateUser).not.toHaveBeenCalled();
     expect(mockUpdateRep).not.toHaveBeenCalled();
-    expect(mockInteraction.reply).toHaveBeenCalled();
-    expect(mockInteraction.reply).toHaveBeenCalledWith("You don't have enough permission to run this command.");
+    expect(interaction.reply).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith("You don't have enough permission to run this command.");
   });
 
-  it('Should call reply when user mentions another user', async () => {
+  chatInputCommandInteractionTest('Should call reply when user mentions another user', async ({ interaction }) => {
     mockCreateUpdateUser.mockResolvedValueOnce({ id: '1', reputation: 1 }).mockResolvedValueOnce({ id: '0', reputation: 1 });
     mockUpdateRep.mockResolvedValueOnce({ id: '0', reputation: 1234 });
     const mockUser = { id: '0' } as User;
-    mockInteraction.member!.user.id = '1';
-    mockInteraction.options.getUser.mockReturnValueOnce(mockUser);
-    mockInteraction.options.getInteger.mockReturnValueOnce(1234);
-    mockInteraction.guild!.members.cache.get.mockImplementation((key) => {
+    interaction.member!.user.id = '1';
+    interaction.options.getUser.mockReturnValueOnce(mockUser);
+    interaction.options.getInteger.mockReturnValueOnce(1234);
+    interaction.guild!.members.cache.get.mockImplementation((key) => {
       return { displayName: `test${key}` } as GuildMember;
     });
 
-    await setReputation(mockInteraction);
+    await setReputation(interaction);
 
     expect(mockCreateUpdateUser).toHaveBeenCalledTimes(2);
     expect(mockUpdateRep).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith("test1 just set test0's rep to 1234.\ntest0 → 1234 reps");
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith("test1 just set test0's rep to 1234.\ntest0 → 1234 reps");
   });
 });

--- a/src/slash-commands/reputation/take-reputation.test.ts
+++ b/src/slash-commands/reputation/take-reputation.test.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction, GuildMember, User } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep, mockReset } from 'vitest-mock-extended';
 import { isAdmin } from '../../utils/permission';
 import { takeReputation } from './take-reputation';

--- a/src/slash-commands/server-settings/index.ts
+++ b/src/slash-commands/server-settings/index.ts
@@ -1,4 +1,4 @@
-import { type GuildMember, InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import { InteractionContextType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import type { SlashCommand, SlashCommandHandler } from '../builder';
 import setAocSettings from './set-aoc-settings';
 import setReminderChannel from './set-reminder-channel';

--- a/src/slash-commands/server-settings/set-aoc-settings.test.ts
+++ b/src/slash-commands/server-settings/set-aoc-settings.test.ts
@@ -1,24 +1,18 @@
 import { faker } from '@faker-js/faker';
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { execute } from './set-aoc-settings';
 import { setAocSettings } from './utils';
 
 vi.mock('./utils');
 const mockSetAocSettings = vi.mocked(setAocSettings);
-const mockChatInputInteraction = mockDeep<ChatInputCommandInteraction>();
 const mockKey = faker.string.alphanumeric({ length: 127 });
 const mockLeaderboardId = faker.string.alphanumeric();
 
 describe('Set aoc key', () => {
-  beforeEach(() => {
-    mockReset(mockChatInputInteraction);
-  });
-
-  it('should reply with error if it cannot set the key', async () => {
+  chatInputCommandInteractionTest('should reply with error if it cannot set the key', async ({ interaction }) => {
     mockSetAocSettings.mockRejectedValueOnce(new Error('Synthetic Error save aoc settings'));
-    mockChatInputInteraction.options.getString.mockImplementation((name) => {
+    interaction.options.getString.mockImplementation((name) => {
       switch (name) {
         case 'key': {
           return mockKey;
@@ -33,19 +27,19 @@ describe('Set aoc key', () => {
       }
     });
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
     expect(mockSetAocSettings).toHaveBeenCalledOnce();
-    expect(mockChatInputInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockChatInputInteraction.reply).toHaveBeenCalledWith('Cannot set this AOC key. Please try again. Error: Error: Synthetic Error save aoc settings');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Cannot set this AOC key. Please try again. Error: Error: Synthetic Error save aoc settings');
   });
 
-  it('Should be able to set AOC key and reply', async () => {
+  chatInputCommandInteractionTest('Should be able to set AOC key and reply', async ({ interaction }) => {
     mockSetAocSettings.mockResolvedValueOnce({
       guildId: faker.string.numeric(),
       aocLeaderboardId: faker.string.numeric(),
     });
-    mockChatInputInteraction.options.getString.mockImplementation((name) => {
+    interaction.options.getString.mockImplementation((name) => {
       switch (name) {
         case 'key': {
           return mockKey;
@@ -60,10 +54,10 @@ describe('Set aoc key', () => {
       }
     });
 
-    await execute(mockChatInputInteraction);
+    await execute(interaction);
 
     expect(mockSetAocSettings).toHaveBeenCalledOnce();
-    expect(mockChatInputInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockChatInputInteraction.reply).toHaveBeenCalledWith('Successfully saved setting. You can now get AOC Leaderboard.');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Successfully saved setting. You can now get AOC Leaderboard.');
   });
 });

--- a/src/slash-commands/server-settings/set-reminder-channel.test.ts
+++ b/src/slash-commands/server-settings/set-reminder-channel.test.ts
@@ -1,42 +1,37 @@
-import type { ChatInputCommandInteraction, TextChannel } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import type { TextChannel } from 'discord.js';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { execute } from './set-reminder-channel';
 import { setReminderChannel } from './utils';
 
 vi.mock('./utils');
 const mockSetReminderChannel = vi.mocked(setReminderChannel);
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
 const channelId = 'channel_12345';
 
 describe('Set reminder channel', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
-
-  it('Should reply with error if it cannot set the channel', async () => {
+  chatInputCommandInteractionTest('Should reply with error if it cannot set the channel', async ({ interaction }) => {
     mockSetReminderChannel.mockRejectedValueOnce(new Error('Synthetic Error'));
-    mockInteraction.options.getChannel.mockReturnValueOnce({
+    interaction.options.getChannel.mockReturnValueOnce({
       id: channelId,
     } as TextChannel);
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockSetReminderChannel).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith('Cannot save this reminder channel for this server. Please try again.');
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith('Cannot save this reminder channel for this server. Please try again.');
   });
 
-  it('Should be able to set channel and reply', async () => {
+  chatInputCommandInteractionTest('Should be able to set channel and reply', async ({ interaction }) => {
     mockSetReminderChannel.mockResolvedValueOnce(channelId);
-    mockInteraction.options.getChannel.mockReturnValueOnce({
+    interaction.options.getChannel.mockReturnValueOnce({
       id: channelId,
     } as TextChannel);
 
-    await execute(mockInteraction);
+    await execute(interaction);
 
     expect(mockSetReminderChannel).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledOnce();
-    expect(mockInteraction.reply).toHaveBeenCalledWith(`Sucessfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
+    expect(interaction.reply).toHaveBeenCalledOnce();
+    expect(interaction.reply).toHaveBeenCalledWith(`Sucessfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
   });
 });

--- a/src/slash-commands/weather/index.test.ts
+++ b/src/slash-commands/weather/index.test.ts
@@ -1,68 +1,62 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
 import { http, HttpResponse } from 'msw';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { captor, mockDeep, mockReset } from 'vitest-mock-extended';
+import { describe, expect } from 'vitest';
+import { captor } from 'vitest-mock-extended';
 import { DEFAULT_LOCATION, weather } from '.';
+import { chatInputCommandInteractionTest } from '../../../test/fixtures/chat-input-command-interaction';
 import { server } from '../../../test/mocks/msw/server';
 import { WEATHER_URL } from './fetch-weather';
 
-const mockInteraction = mockDeep<ChatInputCommandInteraction>();
-
 describe('Weather test', () => {
-  beforeEach(() => {
-    mockReset(mockInteraction);
-  });
+  chatInputCommandInteractionTest('Should reply command with weather data', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('Hanoi');
 
-  it('Should reply command with weather data', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('Hanoi');
-
-    await weather(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    await weather(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
 
     const message = captor<string>();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith(message);
+    expect(interaction.editReply).toHaveBeenCalledWith(message);
     expect(message.value).toContain('Hanoi');
   });
 
-  it('Should run with default input if no input is given', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('');
+  chatInputCommandInteractionTest('Should run with default input if no input is given', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('');
 
-    await weather(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    await weather(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
 
     const message = captor<string>();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith(message);
+    expect(interaction.editReply).toHaveBeenCalledWith(message);
     expect(message.value).toContain(DEFAULT_LOCATION);
   });
 
-  it('Should construct the URL correctly if input has many words', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('Ho Chi Minh City');
+  chatInputCommandInteractionTest('Should construct the URL correctly if input has many words', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('Ho Chi Minh City');
 
-    await weather(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
+    await weather(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
 
     const message = captor<string>();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith(message);
+    expect(interaction.editReply).toHaveBeenCalledWith(message);
     expect(message.value).toContain('Ho+Chi+Minh+City');
   });
 
-  it('Should reply with error if given an error location', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('ErrorLocation');
+  chatInputCommandInteractionTest('Should reply with error if given an error location', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('ErrorLocation');
 
-    await weather(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith('Error getting weather data for location.');
+    await weather(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    expect(interaction.editReply).toHaveBeenCalledWith('Error getting weather data for location.');
   });
 
-  it('Should reply with error if input is valid but weather data cannot be downloaded', async () => {
-    mockInteraction.options.getString.mockReturnValueOnce('Brisbane');
+  chatInputCommandInteractionTest('Should reply with error if input is valid but weather data cannot be downloaded', async ({ interaction }) => {
+    interaction.options.getString.mockReturnValueOnce('Brisbane');
     const endpoint = http.get(`${WEATHER_URL}:location`, () => {
       return HttpResponse.error();
     });
     server.use(endpoint);
 
-    await weather(mockInteraction);
-    expect(mockInteraction.editReply).toHaveBeenCalledOnce();
-    expect(mockInteraction.editReply).toHaveBeenCalledWith('Error getting weather data for location.');
+    await weather(interaction);
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+    expect(interaction.editReply).toHaveBeenCalledWith('Error getting weather data for location.');
   });
 });

--- a/src/utils/message-processor.test.ts
+++ b/src/utils/message-processor.test.ts
@@ -1,5 +1,5 @@
 import type { Message } from 'discord.js';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type CommandConfig, processMessage } from './message-processor';
 
 describe('processMessage', () => {

--- a/test/fixtures/autocomplete-interaction.ts
+++ b/test/fixtures/autocomplete-interaction.ts
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker';
+import type { AutocompleteInteraction } from 'discord.js';
+import { test } from 'vitest';
+import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
+
+interface AutocompleteInteractionTest {
+  interaction: DeepMockProxy<AutocompleteInteraction>;
+}
+
+const interaction = mockDeep<AutocompleteInteraction>();
+
+const guildId = `guild_${faker.string.nanoid()}`;
+
+export const autocompleteInteractionTest = test.extend<AutocompleteInteractionTest>({
+  interaction: async ({}, use) => {
+    interaction.guildId = guildId;
+
+    await use(interaction);
+
+    mockReset(interaction);
+  },
+});

--- a/test/fixtures/chat-input-command-interaction.ts
+++ b/test/fixtures/chat-input-command-interaction.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { test } from 'vitest';
+import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
+
+interface ChatInputCommandInteractionTest {
+  interaction: DeepMockProxy<ChatInputCommandInteraction>;
+}
+
+export const chatInputCommandInteractionTest = test.extend<ChatInputCommandInteractionTest>({
+  interaction: async ({}, use) => {
+    const interaction = mockDeep<ChatInputCommandInteraction>();
+    interaction.guildId = faker.string.nanoid();
+
+    await use(interaction);
+
+    mockReset(interaction);
+  },
+});

--- a/test/fixtures/chat-input-command-interaction.ts
+++ b/test/fixtures/chat-input-command-interaction.ts
@@ -1,19 +1,31 @@
 import { faker } from '@faker-js/faker';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, Message } from 'discord.js';
 import { test } from 'vitest';
 import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
 
 interface ChatInputCommandInteractionTest {
   interaction: DeepMockProxy<ChatInputCommandInteraction>;
+  message: DeepMockProxy<Message<true>>;
 }
+
+const interaction = mockDeep<ChatInputCommandInteraction>();
+const message = mockDeep<Message<true>>();
+
+const guildId = faker.string.nanoid();
 
 export const chatInputCommandInteractionTest = test.extend<ChatInputCommandInteractionTest>({
   interaction: async ({}, use) => {
-    const interaction = mockDeep<ChatInputCommandInteraction>();
-    interaction.guildId = faker.string.nanoid();
+    interaction.guildId = guildId;
 
     await use(interaction);
 
     mockReset(interaction);
+  },
+  message: async ({}, use) => {
+    message.guildId = guildId;
+
+    await use(message);
+
+    mockReset(message);
   },
 });

--- a/test/fixtures/chat-input-command-interaction.ts
+++ b/test/fixtures/chat-input-command-interaction.ts
@@ -1,17 +1,20 @@
 import { faker } from '@faker-js/faker';
-import type { ChatInputCommandInteraction, Message } from 'discord.js';
+import type { ChatInputCommandInteraction, Message, PublicThreadChannel } from 'discord.js';
 import { test } from 'vitest';
 import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
 
 interface ChatInputCommandInteractionTest {
   interaction: DeepMockProxy<ChatInputCommandInteraction>;
   message: DeepMockProxy<Message<true>>;
+  thread: DeepMockProxy<PublicThreadChannel>;
 }
 
 const interaction = mockDeep<ChatInputCommandInteraction>();
 const message = mockDeep<Message<true>>();
+const thread = mockDeep<PublicThreadChannel>();
 
-const guildId = faker.string.nanoid();
+const guildId = `guild_${faker.string.nanoid()}`;
+const threadId = `thread_${faker.string.nanoid()}`;
 
 export const chatInputCommandInteractionTest = test.extend<ChatInputCommandInteractionTest>({
   interaction: async ({}, use) => {
@@ -27,5 +30,12 @@ export const chatInputCommandInteractionTest = test.extend<ChatInputCommandInter
     await use(message);
 
     mockReset(message);
+  },
+  thread: async ({}, use) => {
+    thread.id = threadId;
+
+    await use(thread);
+
+    mockReset(thread);
   },
 });

--- a/test/fixtures/context-menu-command-interaction.ts
+++ b/test/fixtures/context-menu-command-interaction.ts
@@ -1,0 +1,17 @@
+import type { MessageContextMenuCommandInteraction } from 'discord.js';
+import { test } from 'vitest';
+import { type DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
+
+interface ContextMenuCommandTest {
+  interaction: DeepMockProxy<MessageContextMenuCommandInteraction>;
+}
+
+export const contextMenuCommandTest = test.extend<ContextMenuCommandTest>({
+  interaction: async ({}, use) => {
+    const interaction = mockDeep<MessageContextMenuCommandInteraction>();
+
+    await use(interaction);
+
+    mockReset(interaction);
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ESNext"],
-    "types": ["node", "vitest/globals"],
+    "types": ["node"],
     "allowJs": true,
     "declaration": true,
     "skipLibCheck": true,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    // globals: true,
     coverage: {
       enabled: true,
       provider: 'v8',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    globals: true,
+    // globals: true,
     coverage: {
       enabled: true,
       provider: 'v8',


### PR DESCRIPTION
Up until now, we've had a lot of manual test setups, and that has been improved with `vitest-mock-extended`, but it's still very manual.

This PR will introduce some test fixtures that can be reused across the repos so it will be a lot easier to setup and teardown tests.