### PR TITLE
chore: update OTel docs on OTel abbreviation casing and update test fixture

### DIFF
--- a/.agents/rules/communication.md
+++ b/.agents/rules/communication.md
@@ -73,3 +73,4 @@
 ## Formatting and Style Guidelines
 
 - Use dashes for lists in markdown documents instead of literal dots, especially in commit messages
+- When referring to OpenTelemetry, always use the abbreviation `OTel` (not `OTEL`). The only time `OTEL` appears in full caps is in environment variable names (e.g., `ENABLE_OTEL`, `OTEL_DEBUG`). This follows the [official OpenTelemetry glossary](https://opentelemetry.io/docs/concepts/glossary/#otel).

--- a/docs/explanation/01-architecture.md
+++ b/docs/explanation/01-architecture.md
@@ -44,20 +44,20 @@ The `getOrCreateUser` pattern (find or create) trades a potential extra database
 
 Logging uses [Winston](https://www.npmjs.com/package/winston) locally (console with pretty-printing) and [Axiom](https://axiom.co/) in production (centralised log aggregation). This split allows development debugging without external dependencies while providing searchable, persistent logs in production.
 
-When OpenTelemetry is enabled (`ENABLE_OTEL=true`), `@opentelemetry/instrumentation-winston` (bundled in auto-instrumentations) automatically patches Winston to send logs through the OTEL pipeline. The direct `@axiomhq/winston` transport is kept as a fallback when OTEL is disabled, ensuring production log aggregation is never lost. Once OTEL is stable in production, the `@axiomhq/winston` fallback will be removed.
+When OpenTelemetry is enabled (`ENABLE_OTEL=true`), `@opentelemetry/instrumentation-winston` (bundled in auto-instrumentations) automatically patches Winston to send logs through the OTel pipeline. The direct `@axiomhq/winston` transport is kept as a fallback when OTel is disabled, ensuring production log aggregation is never lost. Once OTel is stable in production, the `@axiomhq/winston` fallback will be removed.
 
 ## Why OpenTelemetry
 
-The bot uses [OpenTelemetry](https://opentelemetry.io/) (OTEL) for distributed tracing. OTEL is a vendor-neutral observability standard — traces can be exported to any compatible backend without changing application code.
+The bot uses [OpenTelemetry](https://opentelemetry.io/) (OTel) for instrumenting, generating, collecting and exporting telemetry data (like traces, metrics and logs). OTel is a vendor-neutral observability standard — telemetry data can be exported to any compatible backend without changing application code.
 
 This was chosen over vendor-specific SDKs (e.g., Axiom's own SDK) because:
 
-- **Vendor independence** — switching backends (Axiom, Grafana, Datadog) requires only a config change, not a code rewrite
+- **Vendor independence** — switching backends (Axiom, Grafana, Datadog) requires only a config change, not a complete code rewrite, as long as the provider accepts the [OpenTelemtry Protocol](https://opentelemetry.io/docs/specs/otlp/) (or OTLP)
 - **Standardised semantic conventions** — attributes like `messaging.system`, `enduser.id`, and `error.type` follow an industry standard, making traces readable by anyone familiar with OTEL
 
 Locally, [Jaeger](https://www.jaegertracing.io/) provides a lightweight trace viewer with span graph visualisation. In production, traces export to [Axiom](https://axiom.co/) for centralised observability. The `FilteringSpanProcessor` reduces production costs by dropping unprocessed messages entirely and sampling success spans at 1%, while always exporting error spans.
 
-OTEL is disabled by default (`ENABLE_OTEL=false`) and has no impact on bot behaviour when off.
+OTel is disabled by default (`ENABLE_OTEL=false`) and has no impact on bot behaviour when off.
 
 ## Why In-Memory Caching for Honeypot
 

--- a/docs/reference/05-environment-variables.md
+++ b/docs/reference/05-environment-variables.md
@@ -38,15 +38,15 @@ All configuration is via environment variables in the `.env` file. Copy `.env.di
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ENABLE_OTEL` | No | `false` | Enable OpenTelemetry trace collection (`true` or `false`) |
-| `OTEL_DEBUG` | No | `false` | Enable OTEL SDK diagnostic logging |
+| `OTEL_DEBUG` | No | `false` | Enable OTel SDK diagnostic logging |
 | `OTEL_SERVICE_NAME` | No | `vait-discord-bot` | Service name for trace attribution |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | When OTEL enabled | — | OTLP HTTP base endpoint URL. The SDK appends signal-specific paths (`/v1/traces`, `/v1/logs`) automatically. Local dev: `http://localhost:4318` (Jaeger). |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | When OTel enabled | — | OTLP HTTP base endpoint URL. The SDK appends signal-specific paths (`/v1/traces`, `/v1/logs`) automatically. Local dev: `http://localhost:4318` (Jaeger). |
 
-When `ENABLE_OTEL=true` in production, `AXIOM_TOKEN` and `AXIOM_DATASET` are also required (traces and logs are exported to Axiom via the OTEL pipeline). When `ENABLE_OTEL=false`, logs fall back to the direct `@axiomhq/winston` transport.
+When `ENABLE_OTEL=true` in production, `AXIOM_TOKEN` and `AXIOM_DATASET` are also required (traces and logs are exported to Axiom via the OTel pipeline). When `ENABLE_OTEL=false`, logs fall back to the direct `@axiomhq/winston` transport.
 
 ## System
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `NODE_ENV` | No | `development` | Environment mode (`development`, `production`, or `test`). Drives environment-specific validation: `GUILD_ID` is required in development, Axiom variables are required in production, and `OTEL_EXPORTER_OTLP_ENDPOINT` is required when OTEL is enabled. |
+| `NODE_ENV` | No | `development` | Environment mode (`development`, `production`, or `test`). Drives environment-specific validation: `GUILD_ID` is required in development, Axiom variables are required in production, and `OTEL_EXPORTER_OTLP_ENDPOINT` is required when OTel is enabled. |
 | `TZ` | No | `Australia/Brisbane` | Timezone for the bot process |

--- a/src/utils/message-processor.test.ts
+++ b/src/utils/message-processor.test.ts
@@ -1,13 +1,9 @@
-import type { Message } from 'discord.js';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
+import { chatInputCommandInteractionTest } from '../../test/fixtures/chat-input-command-interaction';
 import { type CommandConfig, processMessage } from './message-processor';
 
 describe('processMessage', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
-  it('process keyword matches', async () => {
+  chatInputCommandInteractionTest('process keyword matches', async ({ message, channel }) => {
     const km1 = vi.fn();
     const km2 = vi.fn();
     const noMatch = vi.fn();
@@ -29,9 +25,10 @@ describe('processMessage', () => {
       ],
     };
 
-    const message = {
-      content: 'star this thing :sadparrot:',
-    } as Message<true>;
+    message.content = 'star this thing :sadparrot:';
+    message.channelId = channel.id;
+    message.id = 'test-message-id';
+    message.author.id = 'test-author-id';
 
     await processMessage(message, config);
 


### PR DESCRIPTION
## Description
Two small housekeeping changes:

1. **Standardize OTel casing** — replaced `OTEL` with `OTel` in prose across architecture docs, environment variable docs, and agent communication rules. Environment variable *names* (e.g. `ENABLE_OTEL`, `OTEL_DEBUG`) are unchanged. Also updated the "Why OpenTelemetry" section with more accurate descriptions from the official docs.
2. **Use shared test fixture in message processor tests** — replaced the hand-rolled `Message` stub with the `chatInputCommandInteractionTest` fixture, aligning with the pattern used elsewhere in the test suite.

## Motivation and Context
- OTel casing follows the [official OpenTelemetry glossary](https://opentelemetry.io/docs/concepts/glossary/#otel) convention.
- The test fixture swap reduces duplication and ensures the message processor tests use a realistic Discord interaction shape.

## How Has This Been Tested?
- Existing tests pass with the updated fixture.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.