### PR TITLE
chore: deduplicate agent rules, link to docs as source of truth

### DIFF
--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -18,6 +18,8 @@
 
 ## Naming Conventions
 
+> See also: [`docs/reference/03-project-structure.md`](../../docs/reference/03-project-structure.md)
+
 - **Variables/Functions**: camelCase (`getUserData`, `messageContent`)
 - **Types/Interfaces/Classes**: PascalCase (`UserData`, `CommandHandler`)
 - **Constants**: UPPER_SNAKE_CASE (`MAX_RETRIES`, `DEFAULT_TIMEOUT`)
@@ -26,6 +28,8 @@
 - **Private members**: Prefix with `_` when needed (`_internalState`)
 
 ## Project Structure
+
+> See also: [`docs/reference/03-project-structure.md`](../../docs/reference/03-project-structure.md)
 
 - **Documentation**: `/docs/` (Diataxis framework: tutorials, how-to, reference, explanation)
 - **Slash Commands**: `/src/slash-commands/[command-name]/index.ts`

--- a/.agents/rules/commands.md
+++ b/.agents/rules/commands.md
@@ -1,37 +1,11 @@
 # Rule: Commands Reference
 
-## Development
+> Full reference: [`docs/reference/02-pnpm-scripts.md`](../../docs/reference/02-pnpm-scripts.md)
 
-- **Install**: `pnpm install` (install dependencies)
-- **Start**: `pnpm start` (run bot locally with database migrations)
-- **Start Only**: `pnpm start:only` (run bot without migrations, with hot reload)
-- **Build**: `pnpm build` (production build)
-- **Build with Typecheck**: `pnpm build:typecheck` (build after typecheck)
-- **Typecheck**: `pnpm typecheck` (type checking only)
+## Quick Reference
 
-## Code Quality
-
-- **Lint**: `pnpm lint` (check for linting issues)
-- **Lint Fix**: `pnpm lint:fix` (auto-fix safe linting issues)
-- **Lint Fix Unsafe**: `pnpm lint:fix:unsafe` (auto-fix including unsafe transformations)
-- **Format**: `pnpm format` (format code with Biome and Prisma formatter)
-- **Test**: `pnpm test` (run all tests)
-- **Test Single File**: `pnpm test path/to/test.test.ts` (run specific test file)
-- **Test Silent**: `pnpm test:silent` (run tests without console output)
-- **CI Check**: `pnpm ci` (run full CI checks locally)
-
-## Database
-
-- **Migrate**: `pnpm prisma:migrate` (run database migrations)
-- **Generate**: `pnpm prisma:gen` (generate Prisma client)
-- **Studio**: `pnpm prisma:studio` (open Prisma Studio GUI)
-
-## Discord Commands
-
-- **Deploy Commands**: `pnpm deploy:command` (deploy commands to guild, use sparingly to avoid rate limits)
-- **Delete Guild Commands**: `pnpm delete:command` (remove guild commands)
-- **Delete Global Commands**: `pnpm delete:command-global` (remove global commands)
-
-## Special
-
-- **Build Referrals**: `pnpm build:referrals` (generate referral list from database)
+- `pnpm start` — run bot with migrations
+- `pnpm test` — run all tests
+- `pnpm lint:fix:unsafe` — auto-fix all linting issues
+- `pnpm ci` — run full CI checks locally
+- `pnpm deploy:command` — deploy Discord commands (use sparingly!)

--- a/.agents/rules/communication.md
+++ b/.agents/rules/communication.md
@@ -22,11 +22,7 @@
 
 ## For Documentation
 
-- **Mandatory**: All project documentation MUST follow the [Diataxis](https://diataxis.fr/) framework
-  - **Tutorials** (`docs/tutorials/`): Learning-oriented, step-by-step walkthroughs for newcomers
-  - **How-to guides** (`docs/how-to/`): Task-oriented, practical recipes for specific goals
-  - **Reference** (`docs/reference/`): Information-oriented, factual lookup material
-  - **Explanation** (`docs/explanation/`): Understanding-oriented, context and design rationale
+- **Mandatory**: All project documentation MUST follow the [Diataxis](https://diataxis.fr/) framework (see [`docs/index.md`](../../docs/index.md) for category definitions and the full doc index)
 - Each document serves ONE Diataxis purpose, never mix categories
 - Documentation lives in `docs/` under the appropriate category directory
 - Lead with context and audience awareness

--- a/.agents/rules/engineering-principles.md
+++ b/.agents/rules/engineering-principles.md
@@ -9,7 +9,10 @@
 
 ## Error Handling
 
+> See also: [`docs/reference/08-error-handling.md`](../../docs/reference/08-error-handling.md)
+
 - **Use Result types**: Prefer `Ok`/`Err` from oxide.ts over throwing exceptions
+- **Record span errors**: Use `recordSpanError` to attach errors to OTel spans
 - **Log errors**: Always log errors with winston logger
 - **User feedback**: Provide clear error messages to Discord users
 - **Graceful degradation**: Bot should continue running even if one command fails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,26 +33,15 @@ All changes must be:
 
 ## Project Structure
 
+> Full layout: [`docs/reference/03-project-structure.md`](docs/reference/03-project-structure.md)
+
 ```
 docs/                            # Project documentation (Diataxis framework)
-  tutorials/                     # Learning-oriented guides
-    developers/                  # For contributors
-    users/                       # For bot users
-  how-to/                        # Task-oriented guides
-  reference/                     # Information-oriented lookup
-  explanation/                   # Understanding-oriented discussion
-  index.md                       # Documentation hub
-
 .agents/
   skills/                        # Task-specific toolkits with proven workflows
-    update-docs/SKILL.md         # Documentation audit and update workflow
   rules/                         # Domain-specific guidelines and constraints
-    commands.md
-    code-style.md
-    patterns.md
-    engineering-principles.md
-    communication.md
-    special-considerations.md
+src/                             # Application source code
+test/                            # Test fixtures, mocks, and helpers
 ```
 
 ## Execution Protocol
@@ -91,9 +80,7 @@ Load a skill when its trigger condition matches the task:
 
 ### Tech Stack
 
-- TypeScript, Node.js 22+, discord.js v14
-- Prisma ORM with PostgreSQL
-- Vitest for testing, MSW for mocking
+See the [README](README.md) for the full tech stack.
 
 ### Essential Commands
 


### PR DESCRIPTION
## Description

Deduplicates content across `.agents/rules/` files and `AGENTS.md` by replacing repeated information with links to the canonical docs in `docs/`. This makes `docs/` the single source of truth and keeps agent rules concise.

## Motivation and Context

Several agent rule files duplicated content already maintained in `docs/`. This created a maintenance burden where changes to docs had to be mirrored in agent rules. By linking instead of repeating, we eliminate drift and reduce file sizes.

## How Has This Been Tested?

- Verified all relative markdown links resolve correctly
- Reviewed each changed file to ensure no essential quick-reference content was lost

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.