### PR TITLE
feat: add span enrichment and error recording to command handlers

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -10,7 +10,7 @@ import { processInteraction } from '../src/utils/interaction-processor';
 import { type ConfigSchema, loadEnv } from '../src/utils/load-env';
 import { logger } from '../src/utils/logger';
 import { processMessage } from '../src/utils/message-processor';
-import { recordSpanError, tracer } from '../src/utils/tracer';
+import { recordSpanError, setSpanAttributes, tracer } from '../src/utils/tracer';
 
 const deployCommands = async ({ token, clientId, nodeEnv }: Omit<DiscordRequestConfig, 'guildId'> & { nodeEnv: ConfigSchema['NODE_ENV'] }) => {
   if (nodeEnv !== 'production') {
@@ -36,6 +36,22 @@ const deployCommands = async ({ token, clientId, nodeEnv }: Omit<DiscordRequestC
   });
 };
 
+const loadHoneypots = async () => {
+  return tracer.startActiveSpan('loadHoneypots', async (span) => {
+    try {
+      const op = await Result.safe(loadHoneypotChannels());
+      if (op.isErr()) {
+        recordSpanError(op.unwrapErr(), 'err-load-honeypots-failed');
+        logger.error('[honeypot]: Failed to load honeypot channels', op.unwrapErr());
+        return;
+      }
+      setSpanAttributes({ 'bot.honeypot.channel_count': op.unwrap() });
+    } finally {
+      span.end();
+    }
+  });
+};
+
 const main = async () => {
   const env = loadEnv();
   logger.info('[main]: STARTING BOT');
@@ -47,10 +63,8 @@ const main = async () => {
 
   await deployCommands({ token: env.TOKEN, clientId: client.user.id, nodeEnv: env.NODE_ENV });
 
-  const honeypotOp = await Result.safe(loadHoneypotChannels());
-  if (honeypotOp.isErr()) {
-    logger.error('[honeypot]: Failed to load honeypot channels', honeypotOp.unwrapErr());
-  }
+  await loadHoneypots();
+
   const configs = getConfigs();
   client.on(Events.MessageCreate, (msg) => {
     return processMessage(msg as Message<true>, configs);

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -38,17 +38,14 @@ const deployCommands = async ({ token, clientId, nodeEnv }: Omit<DiscordRequestC
 
 const loadHoneypots = async () => {
   return tracer.startActiveSpan('loadHoneypots', async (span) => {
-    try {
-      const op = await Result.safe(loadHoneypotChannels());
-      if (op.isErr()) {
-        recordSpanError(op.unwrapErr(), 'err-load-honeypots-failed');
-        logger.error('[honeypot]: Failed to load honeypot channels', op.unwrapErr());
-        return;
-      }
-      setSpanAttributes({ 'bot.honeypot.channel_count': op.unwrap() });
-    } finally {
-      span.end();
+    const op = await Result.safe(loadHoneypotChannels());
+    if (op.isErr()) {
+      recordSpanError(op.unwrapErr(), 'err-load-honeypots-failed');
+      logger.error('[honeypot]: Failed to load honeypot channels', op.unwrapErr());
+      return;
     }
+    setSpanAttributes({ 'bot.honeypot.channel_count': op.unwrap() });
+    span.end();
   });
 };
 

--- a/docs/explanation/01-architecture.md
+++ b/docs/explanation/01-architecture.md
@@ -63,7 +63,7 @@ OTel is disabled by default (`ENABLE_OTEL=false`) and has no impact on bot behav
 
 The bot follows the "wide events" approach to tracing — one rich span per unit of work rather than deep span hierarchies with many child spans.
 
-Each entrypoint — `processInteraction` for Discord commands, `processMessage` for message handlers, or a bin script's `main` function — creates a single root span and enriches it with all relevant attributes. No child spans are created manually.
+Each entrypoint — `processInteraction` for Discord commands, `processMessage` for message handlers, or a bin script's `main` function — creates a single root span. Individual command handlers then enrich that span with domain-specific attributes (e.g., `bot.rep.new_value`, `bot.weather.location`) via `setSpanAttributes()`, and record errors on the span via `recordSpanError()`. No child spans are created manually.
 
 Auto-instrumentation (`@opentelemetry/auto-instrumentations-node`) automatically captures Prisma/PostgreSQL queries and Node.js HTTP calls as child spans beneath the wide root span, providing low-level timing without any manual instrumentation code.
 

--- a/docs/reference/08-error-handling.md
+++ b/docs/reference/08-error-handling.md
@@ -62,6 +62,23 @@ import { logger } from '../../utils/logger';
 | Development | Console with pretty-printing and colours |
 | Production | Console + [Axiom](https://axiom.co/) (including exception and rejection handlers) |
 
+## Span Error Recording
+
+When a command handler catches an error internally (via `Result.safe`), it must record the error on the active OTel span so it appears in traces. Use `recordSpanError` from `src/utils/tracer.ts` before logging.
+
+```typescript
+import { recordSpanError } from '../../utils/tracer';
+
+if (op.isErr()) {
+  recordSpanError(op.unwrapErr(), 'err-command-action-failed');
+  logger.error('[command]: Error message', op.unwrapErr());
+  await interaction.reply('Something went wrong.');
+  return;
+}
+```
+
+Error slugs follow the pattern `err-<command>-<action>-failed` (e.g., `err-reminder-in-failed`, `err-referral-delete-failed`). See [Telemetry](./09-telemetry.md) for the full attribute reference.
+
 ## Discord Error Replies
 
 Ephemeral replies are visible only to the invoking user:

--- a/docs/reference/09-telemetry.md
+++ b/docs/reference/09-telemetry.md
@@ -8,6 +8,7 @@ Reference for the bot's [OpenTelemetry](https://opentelemetry.io/) (OTel) instru
 |--------|-------------|
 | `tracer` | The OTel tracer instance, used to create spans via `tracer.startActiveSpan()` |
 | `recordSpanError(error, slug)` | Records an error on the active span: sets status to ERROR, records the exception, and sets `error.type` to the given slug. No-op when OTel is disabled. |
+| `setSpanAttributes(attributes)` | Sets multiple attributes on the active span in one call. Accepts a `Record<string, string \| number \| boolean>`. No-op when OTel is disabled. |
 
 ## Span Lifecycle
 

--- a/docs/reference/09-telemetry.md
+++ b/docs/reference/09-telemetry.md
@@ -39,6 +39,61 @@ Prefer constants from [`@opentelemetry/semantic-conventions`](https://openteleme
 | `discord.*` | Data received from the Discord API | `discord.guild.id`, `discord.channel.id`, `discord.message.id`, `discord.interaction.type` |
 | `bot.*` | Bot-specific logic and state | `bot.command.name`, `bot.message.processed`, `bot.message.honeypot`, `bot.rep.*`, `bot.reminder.*` |
 
+## Span Enrichment
+
+Command handlers enrich the wide event span with domain-specific attributes via `setSpanAttributes()`. Errors caught internally (via `Result.safe`) are recorded on the span with `recordSpanError()` so they appear in OTel even when the handler replies gracefully to the user.
+
+### Interaction Processor (set on every command span)
+
+| Attribute | Description |
+|-----------|-------------|
+| `enduser.id` | Discord user ID of the invoking user |
+| `discord.guild.id` | Guild where the interaction occurred |
+| `discord.channel.id` | Channel where the interaction occurred |
+| `bot.command.name` | Slash command name |
+| `discord.interaction.type` | `chatInputCommand`, `contextMenuCommand`, or `autocomplete` |
+
+### Command-Specific Attributes
+
+| Command | Attributes |
+|---------|------------|
+| **reputation** (give/set/take) | `bot.rep.actor_user_id`, `bot.rep.target_user_id`, `bot.rep.new_value` |
+| **reputation** (check) | `bot.rep.actor_user_id`, `bot.rep.value` |
+| **reputation** (leaderboard) | `bot.rep.leaderboard_size`, `bot.rep.result_count` |
+| **reminder** (in/on) | `bot.reminder.target_timestamp` |
+| **reminder** (list) | `bot.reminder.count` |
+| **reminder** (delete/update) | `bot.reminder.id` |
+| **referral** (new/delete/update) | `bot.referral.service` |
+| **referral** (list) | `bot.referral.count` |
+| **referral** (random) | `bot.referral.service`, `bot.referral.count` |
+| **weather** | `bot.weather.location`, `bot.weather.success` |
+| **quote-of-the-day** | `bot.quote.success` |
+| **aoc-leaderboard** | `bot.aoc.cached` |
+| **server-settings** | `bot.settings.type`, `bot.settings.channel_id` |
+| **autobump-threads** (add/remove) | `bot.autobump.thread_id` |
+| **autobump-threads** (list) | `bot.autobump.thread_count` |
+| **moderate-users** | `bot.moderate.role_id`, `bot.moderate.members_removed` |
+
+### Message Processor (set on every message span)
+
+| Attribute | Description |
+|-----------|-------------|
+| `enduser.id` | Discord user ID of the message author |
+| `discord.guild.id` | Guild where the message was sent |
+| `discord.channel.id` | Channel where the message was sent |
+| `discord.message.id` | Discord message ID |
+| `bot.message.processed` | Whether any keyword matched |
+| `bot.message.matched_keywords` | Comma-separated list of matched keywords (when processed) |
+| `bot.message.honeypot` | `true` when the message was in a honeypot channel |
+
+### Message Handler Attributes
+
+| Handler | Attributes |
+|---------|------------|
+| **thankUserInMessage** | `bot.rep.actor_user_id`, `bot.rep.mention_count` |
+| **honeypot trigger** | `bot.honeypot.user_id`, `bot.honeypot.ban_success`, `bot.honeypot.timestamp` |
+| **loadHoneypots** (startup) | `bot.honeypot.channel_count` |
+
 ## FilteringSpanProcessor (`src/utils/filtering-span-processor.ts`)
 
 Tail-based sampling that decides after a span ends whether to export it:

--- a/src/slash-commands/aoc-leaderboard/index.test.ts
+++ b/src/slash-commands/aoc-leaderboard/index.test.ts
@@ -7,6 +7,7 @@ import { setAocSettings } from '../server-settings/utils';
 import { execute, formatLeaderboard, getAocYear } from '.';
 import mockAocData from './sample/aoc-data.json';
 import { AocLeaderboard } from './schema';
+import * as utils from './utils';
 import { deleteLeaderboard, saveLeaderboard } from './utils';
 
 const parsedMockData = AocLeaderboard.parse(mockAocData);
@@ -80,6 +81,14 @@ Last updated at: 25/12/2024 16:00
 `);
 
       await deleteLeaderboard(interaction.guildId!);
+    });
+
+    chatInputCommandInteractionTest('Should reply with database error if getSavedLeaderboard fails', async ({ interaction }) => {
+      vi.spyOn(utils, 'getSavedLeaderboard').mockRejectedValueOnce(new Error('connection refused'));
+
+      await execute(interaction);
+
+      expect(interaction.editReply).toHaveBeenCalledWith('ERROR: Error connecting to the database');
     });
 
     chatInputCommandInteractionTest('Should reply with error if server is not configured', async ({ interaction }) => {

--- a/src/slash-commands/aoc-leaderboard/index.ts
+++ b/src/slash-commands/aoc-leaderboard/index.ts
@@ -4,7 +4,7 @@ import { Result } from 'oxide.ts';
 import type { AocLeaderboard as AocLeaderboardModel } from '../../clients/prisma/generated/client/client';
 import { DAY_MONTH_YEAR_HOUR_MINUTE_FORMAT } from '../../utils/date';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 import type { AocLeaderboard as AocLeaderboardSchema } from './schema';
 import { fetchAndSaveLeaderboard, getAocSettings, getSavedLeaderboard } from './utils';
@@ -72,6 +72,7 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
 
   const settingsOp = await Result.safe(getAocSettings(guildId));
   if (settingsOp.isErr()) {
+    recordSpanError(settingsOp.unwrapErr(), 'err-aoc-settings-fetch-failed');
     const errorMessage = 'Error getting AOC settings';
     logger.error(`[get-aoc-leaderboard]: : ${errorMessage}`, settingsOp.unwrapErr());
     await interaction.editReply(`ERROR: ${errorMessage}`);
@@ -89,6 +90,7 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
   const year = getAocYear();
   const fetchAndSaveOp = await Result.safe(fetchAndSaveLeaderboard(year, settings));
   if (fetchAndSaveOp.isErr()) {
+    recordSpanError(fetchAndSaveOp.unwrapErr(), 'err-aoc-leaderboard-fetch-failed');
     const errorMessage = `Error fetching and/or saving new leaderboard result`;
     logger.error(`[get-aoc-leaderboard]: ${errorMessage}`, fetchAndSaveOp.unwrapErr());
     await interaction.editReply(`ERROR: ${errorMessage}`);

--- a/src/slash-commands/aoc-leaderboard/index.ts
+++ b/src/slash-commands/aoc-leaderboard/index.ts
@@ -4,6 +4,7 @@ import { Result } from 'oxide.ts';
 import type { AocLeaderboard as AocLeaderboardModel } from '../../clients/prisma/generated/client/client';
 import { DAY_MONTH_YEAR_HOUR_MINUTE_FORMAT } from '../../utils/date';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 import type { AocLeaderboard as AocLeaderboardSchema } from './schema';
 import { fetchAndSaveLeaderboard, getAocSettings, getSavedLeaderboard } from './utils';
@@ -60,6 +61,7 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
   const getSavedleaderboardOp = await Result.safe(getSavedLeaderboard(guildId));
   const savedResult = getSavedleaderboardOp.unwrap();
   if (!getSavedleaderboardOp.isErr() && savedResult && differenceInMinutes(new Date(), savedResult.updatedAt) <= 15) {
+    setSpanAttributes({ 'bot.aoc.cached': true });
     logger.info('[get-aoc-leaderboard]: Returning saved leaderboard data');
     const formattedLeaderboard = formatLeaderboard(savedResult);
     await interaction.editReply(formattedLeaderboard);
@@ -94,6 +96,7 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
   }
 
   const leaderboardData = fetchAndSaveOp.unwrap();
+  setSpanAttributes({ 'bot.aoc.cached': false });
   const message = formatLeaderboard(leaderboardData);
   await interaction.editReply(message);
 };

--- a/src/slash-commands/aoc-leaderboard/index.ts
+++ b/src/slash-commands/aoc-leaderboard/index.ts
@@ -59,8 +59,15 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
   const guildId = interaction.guildId!;
 
   const getSavedleaderboardOp = await Result.safe(getSavedLeaderboard(guildId));
+  if (getSavedleaderboardOp.isErr()) {
+    recordSpanError(getSavedleaderboardOp.unwrapErr(), 'err-aoc-saved-leaderboard-fetch-failed');
+    logger.error('[get-aoc-leaderboard]: Error connecting to the database', getSavedleaderboardOp.unwrapErr());
+    await interaction.editReply('ERROR: Error connecting to the database');
+    return;
+  }
+
   const savedResult = getSavedleaderboardOp.unwrap();
-  if (!getSavedleaderboardOp.isErr() && savedResult && differenceInMinutes(new Date(), savedResult.updatedAt) <= 15) {
+  if (savedResult && differenceInMinutes(new Date(), savedResult.updatedAt) <= 15) {
     setSpanAttributes({ 'bot.aoc.cached': true });
     logger.info('[get-aoc-leaderboard]: Returning saved leaderboard data');
     const formattedLeaderboard = formatLeaderboard(savedResult);

--- a/src/slash-commands/autobump-threads/add-thread.ts
+++ b/src/slash-commands/autobump-threads/add-thread.ts
@@ -1,7 +1,7 @@
 import { ChannelType, SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { addAutobumpThread } from './utils';
 
@@ -25,6 +25,7 @@ export const addAutobumpThreadCommand: SlashCommandHandler = async (interaction)
   setSpanAttributes({ 'bot.autobump.thread_id': thread.id });
   const op = await Result.safe(addAutobumpThread(guildId, thread.id));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-autobump-add-failed');
     logger.error(`[add-autobump-thread]: Cannot save thread ${thread.id} to be autobumped for guild ${guildId}`, op.unwrapErr());
     await interaction.reply('ERROR: Cannot save this thread to be autobumped for this server. Please try again.');
     return;

--- a/src/slash-commands/autobump-threads/add-thread.ts
+++ b/src/slash-commands/autobump-threads/add-thread.ts
@@ -1,6 +1,7 @@
 import { ChannelType, SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { addAutobumpThread } from './utils';
 
@@ -21,6 +22,7 @@ export const addAutobumpThreadCommand: SlashCommandHandler = async (interaction)
     return;
   }
 
+  setSpanAttributes({ 'bot.autobump.thread_id': thread.id });
   const op = await Result.safe(addAutobumpThread(guildId, thread.id));
   if (op.isErr()) {
     logger.error(`[add-autobump-thread]: Cannot save thread ${thread.id} to be autobumped for guild ${guildId}`, op.unwrapErr());

--- a/src/slash-commands/autobump-threads/list-threads.ts
+++ b/src/slash-commands/autobump-threads/list-threads.ts
@@ -2,7 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import type { ServerChannelsSettings } from '../../clients/prisma/generated/client/client';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { listThreadsByGuild } from './utils';
 
@@ -21,6 +21,7 @@ export const listAutobumpThreadsCommand: SlashCommandHandler = async (interactio
   logger.info(`[list-autobump-threads]: Listing autobump threads for guild ${guildId}`);
 
   if (threads.isErr()) {
+    recordSpanError(threads.unwrapErr(), 'err-autobump-list-failed');
     logger.error(`[list-autobump-threads]: Cannot get list of threads from the database for guild ${guildId}`, threads.unwrapErr());
     await interaction.reply("ERROR: Cannot get list of threads from the database, maybe the server threads aren't setup yet?");
     return;

--- a/src/slash-commands/autobump-threads/list-threads.ts
+++ b/src/slash-commands/autobump-threads/list-threads.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import type { ServerChannelsSettings } from '../../clients/prisma/generated/client/client';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { listThreadsByGuild } from './utils';
 
@@ -26,6 +27,7 @@ export const listAutobumpThreadsCommand: SlashCommandHandler = async (interactio
   }
 
   const data = threads.unwrap();
+  setSpanAttributes({ 'bot.autobump.thread_count': data.length });
   if (data.length === 0) {
     logger.error(`[list-autobump-threads]: No threads have been setup for autobumping in guild ${guildId}`);
     await interaction.reply('ERROR: No threads have been setup for autobumping in this server');

--- a/src/slash-commands/autobump-threads/remove-thread.ts
+++ b/src/slash-commands/autobump-threads/remove-thread.ts
@@ -1,7 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { removeAutobumpThread } from './utils';
 
@@ -18,6 +18,7 @@ export const removeAutobumpThreadCommand: SlashCommandHandler = async (interacti
   setSpanAttributes({ 'bot.autobump.thread_id': thread.id });
   const op = await Result.safe(removeAutobumpThread(guildId, thread.id));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-autobump-remove-failed');
     logger.error(`[remove-autobump-thread]: Cannot remove thread ${thread.id} from autobump list for guild ${guildId}`, op.unwrapErr());
     await interaction.reply(`ERROR: Cannot remove thread id <#${thread.id}> from the bump list for this server. Please try again.`);
     return;

--- a/src/slash-commands/autobump-threads/remove-thread.ts
+++ b/src/slash-commands/autobump-threads/remove-thread.ts
@@ -1,6 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { removeAutobumpThread } from './utils';
 
@@ -14,6 +15,7 @@ export const removeAutobumpThreadCommand: SlashCommandHandler = async (interacti
   const thread = interaction.options.getChannel('thread', true);
   logger.info(`[remove-autobump-thread]: Removing thread ${thread.id} from autobump list for guild ${guildId}`);
 
+  setSpanAttributes({ 'bot.autobump.thread_id': thread.id });
   const op = await Result.safe(removeAutobumpThread(guildId, thread.id));
   if (op.isErr()) {
     logger.error(`[remove-autobump-thread]: Cannot remove thread ${thread.id} from autobump list for guild ${guildId}`, op.unwrapErr());

--- a/src/slash-commands/moderate-users/index.ts
+++ b/src/slash-commands/moderate-users/index.ts
@@ -7,6 +7,7 @@ import {
   type ThreadChannel,
 } from 'discord.js';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 
 const data = new SlashCommandBuilder()
@@ -33,6 +34,7 @@ export const removeUserByRole = async (interaction: ChatInputCommandInteraction)
   const removeMemberPromises = memberList.map((user) => channel.members.remove(user.id));
 
   await Promise.all(removeMemberPromises);
+  setSpanAttributes({ 'bot.moderate.role_id': role.id, 'bot.moderate.members_removed': memberList.size });
   logger.info(`[remove-user-by-role]: Removed ${memberList.size} users from thread ${channel.id}.`);
   await interaction.editReply('Done');
 };

--- a/src/slash-commands/quote-of-the-day/index.ts
+++ b/src/slash-commands/quote-of-the-day/index.ts
@@ -1,6 +1,7 @@
 import { type ChatInputCommandInteraction, EmbedBuilder, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 import { fetchQuote } from './fetch-quote';
 
@@ -11,6 +12,7 @@ export const getQuoteOfTheDay = async (interaction: ChatInputCommandInteraction)
 
   logger.info(`[quote-of-the-day]: ${interaction.user.tag} is getting a quote of the day`);
   const quote = await Result.safe(fetchQuote());
+  setSpanAttributes({ 'bot.quote.success': quote.isOk() });
   if (quote.isErr()) {
     logger.info('[quote-of-the-day]: Error getting quotes', quote.unwrapErr());
     await interaction.editReply('Error getting quotes');

--- a/src/slash-commands/quote-of-the-day/index.ts
+++ b/src/slash-commands/quote-of-the-day/index.ts
@@ -1,7 +1,7 @@
 import { type ChatInputCommandInteraction, EmbedBuilder, InteractionContextType, SlashCommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 import { fetchQuote } from './fetch-quote';
 
@@ -14,6 +14,7 @@ export const getQuoteOfTheDay = async (interaction: ChatInputCommandInteraction)
   const quote = await Result.safe(fetchQuote());
   setSpanAttributes({ 'bot.quote.success': quote.isOk() });
   if (quote.isErr()) {
+    recordSpanError(quote.unwrapErr(), 'err-quote-fetch-failed');
     logger.info('[quote-of-the-day]: Error getting quotes', quote.unwrapErr());
     await interaction.editReply('Error getting quotes');
     return;

--- a/src/slash-commands/referral/referral-delete.ts
+++ b/src/slash-commands/referral/referral-delete.ts
@@ -1,6 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { deleteReferralCode } from './utils';
 
@@ -15,6 +16,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   const userId = interaction.user.id;
   const guildId = interaction.guildId!;
   const service = interaction.options.getString('service', true);
+  setSpanAttributes({ 'bot.referral.service': service });
 
   logger.info(`[referral-delete]: Deleting referral for service ${service} for user ${userId}`);
 

--- a/src/slash-commands/referral/referral-delete.ts
+++ b/src/slash-commands/referral/referral-delete.ts
@@ -1,7 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { deleteReferralCode } from './utils';
 
@@ -29,6 +29,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   );
 
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-referral-delete-failed');
     logger.error('[referral-delete]: Error while deleting referral code', op.unwrapErr());
     await interaction.reply('Failed to delete referral code. Please try again later.');
     return;

--- a/src/slash-commands/referral/referral-list.ts
+++ b/src/slash-commands/referral/referral-list.ts
@@ -3,7 +3,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import type { ReferralCode } from '../../clients/prisma/generated/client/client';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { getUserReferralCodes } from './utils';
 
@@ -37,6 +37,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
 
   const op = await Result.safe(getUserReferralCodes({ userId, guildId }));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-referral-list-failed');
     logger.error('[referral-list]: Error while retrieving referral codes', op.unwrapErr());
     await interaction.reply('There is some error retrieving your referral codes. Please try again later.');
     return;

--- a/src/slash-commands/referral/referral-list.ts
+++ b/src/slash-commands/referral/referral-list.ts
@@ -3,6 +3,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import type { ReferralCode } from '../../clients/prisma/generated/client/client';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { getUserReferralCodes } from './utils';
 
@@ -42,6 +43,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   }
 
   const referrals = op.unwrap();
+  setSpanAttributes({ 'bot.referral.count': referrals.length });
   if (referrals.length === 0) {
     logger.info(`[referral-list]: No referral codes found for user ${userId}`);
     await interaction.reply("You currently don't have any referral codes set up.");

--- a/src/slash-commands/referral/referral-new.ts
+++ b/src/slash-commands/referral/referral-new.ts
@@ -2,6 +2,7 @@ import { addDays, getUnixTime } from 'date-fns';
 import { type Guild, SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { parseDate } from './parse-date';
 import { services } from './services';
@@ -83,6 +84,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     return;
   }
 
+  setSpanAttributes({ 'bot.referral.service': service });
   const newReferralCode = createOp.unwrap();
   await interaction.reply(
     `${nickname} just added referral code ${newReferralCode.code} in ${newReferralCode.service} expired on <t:${getUnixTime(newReferralCode.expiry_date)}:D>`

--- a/src/slash-commands/referral/referral-new.ts
+++ b/src/slash-commands/referral/referral-new.ts
@@ -2,7 +2,7 @@ import { addDays, getUnixTime } from 'date-fns';
 import { type Guild, SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { parseDate } from './parse-date';
 import { services } from './services';
@@ -65,6 +65,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
 
   const findOp = await Result.safe(findExistingReferralCode({ userId, guildId, service }));
   if (findOp.isErr()) {
+    recordSpanError(findOp.unwrapErr(), 'err-referral-new-search-failed');
     logger.error('[referral-new]: Error while searching for referral code', findOp.unwrapErr());
     await interaction.reply('This might be an error with the database. Please try again later.');
     return;
@@ -79,6 +80,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
 
   const createOp = await Result.safe(createReferralCode({ userId, guildId, service, code, expiryDate }));
   if (createOp.isErr()) {
+    recordSpanError(createOp.unwrapErr(), 'err-referral-new-create-failed');
     logger.error('[referral-new]: Error while creating referral code', createOp.unwrapErr());
     await interaction.reply('Failed to add referral code. This might be an error with the database. Please try again later.');
     return;

--- a/src/slash-commands/referral/referral-random.ts
+++ b/src/slash-commands/referral/referral-random.ts
@@ -2,7 +2,7 @@ import { type Guild, SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
 import { getRandomIntInclusive } from '../../utils/random';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { getAllReferralCodesForService } from './utils';
 
@@ -21,6 +21,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
 
   const op = await Result.safe(getAllReferralCodesForService({ guildId, service }));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-referral-random-failed');
     logger.error(`[referral-random]: Error getting referral codes for ${service} service`, op.unwrapErr());
     await interaction.reply(`Error getting referral codes for ${service} service. Please try again later.`);
     return;

--- a/src/slash-commands/referral/referral-random.ts
+++ b/src/slash-commands/referral/referral-random.ts
@@ -2,6 +2,7 @@ import { type Guild, SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
 import { getRandomIntInclusive } from '../../utils/random';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { getAllReferralCodesForService } from './utils';
 
@@ -26,6 +27,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   }
 
   const referrals = op.unwrap();
+  setSpanAttributes({ 'bot.referral.service': service, 'bot.referral.count': referrals.length });
   if (referrals.length === 0) {
     logger.info(`[referral-random]: There is no code for ${service} service in the system.`);
     await interaction.reply(`There is no code for ${service} service in the system.`);

--- a/src/slash-commands/referral/referral-update.ts
+++ b/src/slash-commands/referral/referral-update.ts
@@ -2,6 +2,7 @@ import { getUnixTime } from 'date-fns';
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { parseDate } from './parse-date';
 import { updateReferralCode } from './utils';
@@ -19,6 +20,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   const userId = interaction.user.id;
   const guildId = interaction.guildId!;
   const service = interaction.options.getString('service', true);
+  setSpanAttributes({ 'bot.referral.service': service });
   const code = interaction.options.getString('link_or_code');
   const expiryDateInput = interaction.options.getString('expiry_date');
 

--- a/src/slash-commands/referral/referral-update.ts
+++ b/src/slash-commands/referral/referral-update.ts
@@ -2,7 +2,7 @@ import { getUnixTime } from 'date-fns';
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler } from '../builder';
 import { parseDate } from './parse-date';
 import { updateReferralCode } from './utils';
@@ -61,6 +61,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   );
 
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-referral-update-failed');
     logger.error('[referral-update]: Error while updating referral code', op.unwrapErr());
     await interaction.reply('Failed to update referral code. Please try again later.');
     return;

--- a/src/slash-commands/reminder/list.ts
+++ b/src/slash-commands/reminder/list.ts
@@ -2,7 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import type { Reminder } from '../../clients/prisma/generated/client/client';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { getUserReminders } from './utils';
 
@@ -20,6 +20,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   const guildId = interaction.guildId!;
   const op = await Result.safe(getUserReminders(user.id, guildId));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-reminder-list-failed');
     logger.error('[reminder-list]: Error while retrieving reminders', op.unwrapErr());
     await interaction.reply('There is some error retrieving your reminders. Please try again later.');
     return;

--- a/src/slash-commands/reminder/list.ts
+++ b/src/slash-commands/reminder/list.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import type { Reminder } from '../../clients/prisma/generated/client/client';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { getUserReminders } from './utils';
 
@@ -25,6 +26,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   }
 
   const data = op.unwrap();
+  setSpanAttributes({ 'bot.reminder.count': data.length });
   if (data.length === 0) {
     await interaction.reply("You currently don't have any reminder set up.");
     return;

--- a/src/slash-commands/reminder/remind-duration.ts
+++ b/src/slash-commands/reminder/remind-duration.ts
@@ -3,7 +3,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import parseDuration from 'parse-duration';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { saveReminder } from './utils';
 
@@ -35,6 +35,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   );
 
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-reminder-in-failed');
     logger.error('[reminder-in]: Error while saving reminder', op.unwrapErr());
     await interaction.reply(`Cannot save reminder for <@${user.id}>. Please try again later.`);
     return;

--- a/src/slash-commands/reminder/remind-duration.ts
+++ b/src/slash-commands/reminder/remind-duration.ts
@@ -3,6 +3,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import parseDuration from 'parse-duration';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { saveReminder } from './utils';
 
@@ -39,6 +40,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     return;
   }
 
+  setSpanAttributes({ 'bot.reminder.target_timestamp': op.unwrap().onTimestamp });
   await interaction.reply(`New Reminder for <@${user.id}> set on <t:${op.unwrap().onTimestamp}> with the message: "${message}".`);
 };
 

--- a/src/slash-commands/reminder/remind-on-date.ts
+++ b/src/slash-commands/reminder/remind-on-date.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { convertDateToEpoch } from '../../utils/date';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { saveReminder } from './utils';
 
@@ -32,6 +33,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     return;
   }
 
+  setSpanAttributes({ 'bot.reminder.target_timestamp': op.unwrap().onTimestamp });
   await interaction.reply(`New Reminder for <@${user.id}> set on <t:${op.unwrap().onTimestamp}> with the message: "${message}".`);
 };
 

--- a/src/slash-commands/reminder/remind-on-date.ts
+++ b/src/slash-commands/reminder/remind-on-date.ts
@@ -2,7 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { convertDateToEpoch } from '../../utils/date';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { saveReminder } from './utils';
 
@@ -28,6 +28,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     })
   );
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-reminder-on-failed');
     logger.error('[reminder-on]: Error while saving reminder', op.unwrapErr());
     await interaction.reply(`Cannot save reminder for <@${user.id}>. Please try again later.`);
     return;

--- a/src/slash-commands/reminder/remove.ts
+++ b/src/slash-commands/reminder/remove.ts
@@ -1,7 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { removeReminder } from './utils';
 
@@ -24,6 +24,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     })
   );
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-reminder-delete-failed');
     logger.error('[reminder-delete]: Error while deleting reminder', op.unwrapErr());
     await interaction.reply(`Cannot delete reminder id ${reminderId}. Please try again later.`);
     return;

--- a/src/slash-commands/reminder/remove.ts
+++ b/src/slash-commands/reminder/remove.ts
@@ -1,6 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { removeReminder } from './utils';
 
@@ -13,6 +14,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   const { user } = interaction.member!;
   const guildId = interaction.guildId!;
   const reminderId = interaction.options.getString('id', true);
+  setSpanAttributes({ 'bot.reminder.id': reminderId });
 
   const op = await Result.safe(
     removeReminder({

--- a/src/slash-commands/reminder/update.ts
+++ b/src/slash-commands/reminder/update.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { convertDateToEpoch } from '../../utils/date';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { updateReminder } from './utils';
 
@@ -16,6 +17,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   const { user } = interaction.member!;
   const guildId = interaction.guildId!;
   const reminderId = interaction.options.getString('id', true);
+  setSpanAttributes({ 'bot.reminder.id': reminderId });
   const message = interaction.options.getString('message');
   const dateString = interaction.options.getString('date');
   if (!message && !dateString) {

--- a/src/slash-commands/reminder/update.ts
+++ b/src/slash-commands/reminder/update.ts
@@ -2,7 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { convertDateToEpoch } from '../../utils/date';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { updateReminder } from './utils';
 
@@ -35,6 +35,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     })
   );
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-reminder-update-failed');
     logger.error('[reminder-update]: Error while updating reminder', op.unwrapErr());
     await interaction.reply(`Cannot update reminder for <@${user.id}> and reminder id ${reminderId}. Please try again later.`);
     return;

--- a/src/slash-commands/reputation/check-reputation.ts
+++ b/src/slash-commands/reputation/check-reputation.ts
@@ -10,7 +10,7 @@ export const checkReputation = async (interaction: ChatInputCommandInteraction) 
   const discordUser = interaction.member!.user;
   logger.info(`[reputation]: ${discordUser.username} is checking their reputation`);
   const user = await getOrCreateUser(discordUser.id);
-  setSpanAttributes({ 'bot.rep.value': user.reputation });
+  setSpanAttributes({ 'bot.rep.actor_user_id': discordUser.id, 'bot.rep.value': user.reputation });
   await interaction.reply(`<@${discordUser.id}>: ${user.reputation} Rep`);
 };
 

--- a/src/slash-commands/reputation/check-reputation.ts
+++ b/src/slash-commands/reputation/check-reputation.ts
@@ -1,5 +1,6 @@
 import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { Subcommand } from '../builder';
 import { getOrCreateUser } from './utils';
 
@@ -9,6 +10,7 @@ export const checkReputation = async (interaction: ChatInputCommandInteraction) 
   const discordUser = interaction.member!.user;
   logger.info(`[reputation]: ${discordUser.username} is checking their reputation`);
   const user = await getOrCreateUser(discordUser.id);
+  setSpanAttributes({ 'bot.rep.value': user.reputation });
   await interaction.reply(`<@${discordUser.id}>: ${user.reputation} Rep`);
 };
 

--- a/src/slash-commands/reputation/give-reputation.ts
+++ b/src/slash-commands/reputation/give-reputation.ts
@@ -1,5 +1,6 @@
 import { type ChatInputCommandInteraction, type Message, SlashCommandSubcommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { Subcommand } from '../builder';
 import { getOrCreateUser, updateRep } from './utils';
 
@@ -39,6 +40,7 @@ export const thankUserInMessage = async (msg: Message<true>) => {
     Promise.resolve(`${giver?.displayName} gave 1 rep to the following users:`)
   );
 
+  setSpanAttributes({ 'bot.rep.mention_count': mentionedUsers.size });
   logger.info(`[thank-user-in-message]: ${message}`);
   await channel.send(message);
 };
@@ -59,6 +61,7 @@ export const giveRepSlashCommand = async (interaction: ChatInputCommandInteracti
   }
 
   const updatedUser = await plusRep(author.id, discordUser.id);
+  setSpanAttributes({ 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
   const receiver = interaction.guild?.members.cache.get(discordUser.id);
   const giver = interaction.guild?.members.cache.get(author.id);
   const message = `${giver?.displayName} gave 1 rep to ${receiver?.displayName}.\n${receiver?.displayName} → ${updatedUser.reputation} reps`;

--- a/src/slash-commands/reputation/give-reputation.ts
+++ b/src/slash-commands/reputation/give-reputation.ts
@@ -40,7 +40,7 @@ export const thankUserInMessage = async (msg: Message<true>) => {
     Promise.resolve(`${giver?.displayName} gave 1 rep to the following users:`)
   );
 
-  setSpanAttributes({ 'bot.rep.mention_count': mentionedUsers.size });
+  setSpanAttributes({ 'bot.rep.actor_user_id': author.id, 'bot.rep.mention_count': mentionedUsers.size });
   logger.info(`[thank-user-in-message]: ${message}`);
   await channel.send(message);
 };
@@ -61,7 +61,7 @@ export const giveRepSlashCommand = async (interaction: ChatInputCommandInteracti
   }
 
   const updatedUser = await plusRep(author.id, discordUser.id);
-  setSpanAttributes({ 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
+  setSpanAttributes({ 'bot.rep.actor_user_id': author.id, 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
   const receiver = interaction.guild?.members.cache.get(discordUser.id);
   const giver = interaction.guild?.members.cache.get(author.id);
   const message = `${giver?.displayName} gave 1 rep to ${receiver?.displayName}.\n${receiver?.displayName} → ${updatedUser.reputation} reps`;

--- a/src/slash-commands/reputation/leaderboard.ts
+++ b/src/slash-commands/reputation/leaderboard.ts
@@ -1,5 +1,6 @@
 import { type ChatInputCommandInteraction, SlashCommandSubcommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { Subcommand } from '../builder';
 import { getRepLeaderboard } from './utils';
 
@@ -39,6 +40,7 @@ export const getLeaderboard = async (interaction: ChatInputCommandInteraction) =
   }
 
   const records = await getRepLeaderboard(size);
+  setSpanAttributes({ 'bot.rep.leaderboard_size': size, 'bot.rep.result_count': records.length });
   if (records.length === 0) {
     logger.info('[rep-leaderboard]: no one has rep in this server.');
     await interaction.reply('No one has rep to be on the leaderboard, yet.');

--- a/src/slash-commands/reputation/set-reputation.ts
+++ b/src/slash-commands/reputation/set-reputation.ts
@@ -32,7 +32,7 @@ export const setReputation = async (interaction: ChatInputCommandInteraction) =>
     adjustment: { reputation: { set: repNumber } },
   });
 
-  setSpanAttributes({ 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
+  setSpanAttributes({ 'bot.rep.actor_user_id': author.id, 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
   const receiver = interaction.guild?.members.cache.get(discordUser.id);
   const setter = interaction.guild?.members.cache.get(author.id);
   await interaction.reply(

--- a/src/slash-commands/reputation/set-reputation.ts
+++ b/src/slash-commands/reputation/set-reputation.ts
@@ -1,6 +1,7 @@
 import { type ChatInputCommandInteraction, type GuildMember, SlashCommandSubcommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
 import { isAdmin, isModerator } from '../../utils/permission';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { Subcommand } from '../builder';
 import { getOrCreateUser, updateRep } from './utils';
 
@@ -31,6 +32,7 @@ export const setReputation = async (interaction: ChatInputCommandInteraction) =>
     adjustment: { reputation: { set: repNumber } },
   });
 
+  setSpanAttributes({ 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
   const receiver = interaction.guild?.members.cache.get(discordUser.id);
   const setter = interaction.guild?.members.cache.get(author.id);
   await interaction.reply(

--- a/src/slash-commands/reputation/take-reputation.ts
+++ b/src/slash-commands/reputation/take-reputation.ts
@@ -1,6 +1,7 @@
 import { type ChatInputCommandInteraction, type GuildMember, SlashCommandSubcommandBuilder } from 'discord.js';
 import { logger } from '../../utils/logger';
 import { isAdmin, isModerator } from '../../utils/permission';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { Subcommand } from '../builder';
 import { getOrCreateUser, updateRep } from './utils';
 
@@ -33,6 +34,7 @@ export const takeReputation = async (interaction: ChatInputCommandInteraction) =
     toUserId: user.id,
     adjustment: { reputation: { decrement: 1 } },
   });
+  setSpanAttributes({ 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
   const taken = interaction.guild?.members.cache.get(discordUser.id);
   const taker = interaction.guild?.members.cache.get(author.id);
 

--- a/src/slash-commands/reputation/take-reputation.ts
+++ b/src/slash-commands/reputation/take-reputation.ts
@@ -34,7 +34,7 @@ export const takeReputation = async (interaction: ChatInputCommandInteraction) =
     toUserId: user.id,
     adjustment: { reputation: { decrement: 1 } },
   });
-  setSpanAttributes({ 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
+  setSpanAttributes({ 'bot.rep.actor_user_id': author.id, 'bot.rep.target_user_id': discordUser.id, 'bot.rep.new_value': updatedUser.reputation });
   const taken = interaction.guild?.members.cache.get(discordUser.id);
   const taker = interaction.guild?.members.cache.get(author.id);
 

--- a/src/slash-commands/server-settings/set-aoc-settings.ts
+++ b/src/slash-commands/server-settings/set-aoc-settings.ts
@@ -1,7 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { setAocSettings } from './utils';
 
@@ -19,6 +19,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
 
   const op = await Result.safe(setAocSettings(guildId, key, leaderboardId));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-settings-aoc-save-failed');
     logger.info(`[set-aoc-key]: ${interaction.member!.user.username} failed to set AOC Key. Error: ${op.unwrapErr()}`);
     await interaction.reply(`Cannot set this AOC key. Please try again. Error: ${op.unwrapErr()}`);
     return;

--- a/src/slash-commands/server-settings/set-aoc-settings.ts
+++ b/src/slash-commands/server-settings/set-aoc-settings.ts
@@ -1,6 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { setAocSettings } from './utils';
 
@@ -23,6 +24,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
     return;
   }
 
+  setSpanAttributes({ 'bot.settings.type': 'aoc-key' });
   logger.info(`[set-aoc-key]: ${interaction.member!.user.username} successfully set AOC key for guild ${guildId}`);
   await interaction.reply('Successfully saved setting. You can now get AOC Leaderboard.');
 };

--- a/src/slash-commands/server-settings/set-honeypot-channel.ts
+++ b/src/slash-commands/server-settings/set-honeypot-channel.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { setHoneypotChannelId } from '../../utils/honeypot-handler';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { setHoneypotChannel } from './utils';
 
@@ -22,6 +23,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   }
 
   const channelId = op.unwrap();
+  setSpanAttributes({ 'bot.settings.type': 'honeypot-channel', 'bot.settings.channel_id': channelId });
   setHoneypotChannelId(guildId, channelId);
   logger.info(`[set-honeypot-channel]: ${interaction.member!.user.username} successfully set honeypot channel to ${channel.name}`);
   await interaction.reply(`Successfully saved setting. Honeypot channel set to <#${channelId}>`);

--- a/src/slash-commands/server-settings/set-honeypot-channel.ts
+++ b/src/slash-commands/server-settings/set-honeypot-channel.ts
@@ -2,7 +2,7 @@ import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { setHoneypotChannelId } from '../../utils/honeypot-handler';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { setHoneypotChannel } from './utils';
 
@@ -17,6 +17,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   logger.info(`[set-honeypot-channel]: ${interaction.member!.user.username} is setting honeypot channel to ${channel.name}`);
   const op = await Result.safe(setHoneypotChannel(guildId, channel.id));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-settings-honeypot-save-failed');
     logger.error(`[set-honeypot-channel]: ${interaction.member!.user.username} failed to set honeypot channel to ${channel.name}`, op.unwrapErr());
     await interaction.reply('Cannot save this honeypot channel for this server. Please try again.');
     return;

--- a/src/slash-commands/server-settings/set-reminder-channel.test.ts
+++ b/src/slash-commands/server-settings/set-reminder-channel.test.ts
@@ -27,6 +27,6 @@ describe('Set reminder channel', () => {
     await execute(interaction);
 
     expect(interaction.reply).toHaveBeenCalledOnce();
-    expect(interaction.reply).toHaveBeenCalledWith(`Sucessfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
+    expect(interaction.reply).toHaveBeenCalledWith(`Successfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
   });
 });

--- a/src/slash-commands/server-settings/set-reminder-channel.ts
+++ b/src/slash-commands/server-settings/set-reminder-channel.ts
@@ -1,6 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { setReminderChannel } from './utils';
 
@@ -21,6 +22,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   }
 
   const channelId = op.unwrap();
+  setSpanAttributes({ 'bot.settings.type': 'reminder-channel', 'bot.settings.channel_id': channelId });
   logger.info(`[set-reminder-channel]: ${interaction.member!.user.username} successfully set reminder channel to ${channel.name}`);
   await interaction.reply(`Sucessfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
 };

--- a/src/slash-commands/server-settings/set-reminder-channel.ts
+++ b/src/slash-commands/server-settings/set-reminder-channel.ts
@@ -25,7 +25,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   const channelId = op.unwrap();
   setSpanAttributes({ 'bot.settings.type': 'reminder-channel', 'bot.settings.channel_id': channelId });
   logger.info(`[set-reminder-channel]: ${interaction.member!.user.username} successfully set reminder channel to ${channel.name}`);
-  await interaction.reply(`Sucessfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
+  await interaction.reply(`Successfully saved setting. Reminders will be broadcasted in <#${channelId}>`);
 };
 
 const command: Subcommand = {

--- a/src/slash-commands/server-settings/set-reminder-channel.ts
+++ b/src/slash-commands/server-settings/set-reminder-channel.ts
@@ -1,7 +1,7 @@
 import { SlashCommandSubcommandBuilder } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommandHandler, Subcommand } from '../builder';
 import { setReminderChannel } from './utils';
 
@@ -16,6 +16,7 @@ export const execute: SlashCommandHandler = async (interaction) => {
   logger.info(`[set-reminder-channel]: ${interaction.member!.user.username} is setting reminder channel to ${channel.name}`);
   const op = await Result.safe(setReminderChannel(guildId, channel.id));
   if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-settings-reminder-save-failed');
     logger.error(`[set-reminder-channel]: ${interaction.member!.user.username} failed to set reminder channel to ${channel.name}`, op.unwrapErr());
     await interaction.reply('Cannot save this reminder channel for this server. Please try again.');
     return;

--- a/src/slash-commands/weather/index.ts
+++ b/src/slash-commands/weather/index.ts
@@ -2,6 +2,7 @@ import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandB
 import { Result } from 'oxide.ts';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
+import { setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 import { fetchWeather } from './fetch-weather';
 
@@ -24,6 +25,7 @@ export const weather = async (interaction: ChatInputCommandInteraction) => {
   logger.info(`[weather]: ${interaction.user.tag} is getting the weather for location ${location}`);
 
   const weatherData = await Result.safe(fetchWeather(location));
+  setSpanAttributes({ 'bot.weather.location': location, 'bot.weather.success': weatherData.isOk() });
   if (weatherData.isErr()) {
     logger.info('[weather]: Error getting weather data', weatherData.unwrapErr());
     await interaction.editReply('Error getting weather data for location.');

--- a/src/slash-commands/weather/index.ts
+++ b/src/slash-commands/weather/index.ts
@@ -2,7 +2,7 @@ import { type ChatInputCommandInteraction, InteractionContextType, SlashCommandB
 import { Result } from 'oxide.ts';
 import { isBlank } from '../../utils/is-blank';
 import { logger } from '../../utils/logger';
-import { setSpanAttributes } from '../../utils/tracer';
+import { recordSpanError, setSpanAttributes } from '../../utils/tracer';
 import type { SlashCommand } from '../builder';
 import { fetchWeather } from './fetch-weather';
 
@@ -27,6 +27,7 @@ export const weather = async (interaction: ChatInputCommandInteraction) => {
   const weatherData = await Result.safe(fetchWeather(location));
   setSpanAttributes({ 'bot.weather.location': location, 'bot.weather.success': weatherData.isOk() });
   if (weatherData.isErr()) {
+    recordSpanError(weatherData.unwrapErr(), 'err-weather-fetch-failed');
     logger.info('[weather]: Error getting weather data', weatherData.unwrapErr());
     await interaction.editReply('Error getting weather data for location.');
     return;

--- a/src/utils/honeypot-handler.ts
+++ b/src/utils/honeypot-handler.ts
@@ -2,7 +2,7 @@ import type { Message } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDbClient } from '../clients';
 import { logger } from './logger';
-import { setSpanAttributes } from './tracer';
+import { recordSpanError, setSpanAttributes } from './tracer';
 
 const honeypotChannels = new Map<string, string>();
 
@@ -61,6 +61,7 @@ export const handleHoneypotTrigger = async (message: Message<true>): Promise<voi
   if (result.isOk()) {
     logger.info(`[honeypot]: Banned ${author.username} from guild ${guild.name}`);
   } else {
+    recordSpanError(result.unwrapErr(), 'err-honeypot-ban-failed');
     logger.error(`[honeypot]: Failed to ban ${author.username}`, result.unwrapErr());
   }
 };

--- a/src/utils/honeypot-handler.ts
+++ b/src/utils/honeypot-handler.ts
@@ -2,6 +2,7 @@ import type { Message } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDbClient } from '../clients';
 import { logger } from './logger';
+import { setSpanAttributes } from './tracer';
 
 const honeypotChannels = new Map<string, string>();
 
@@ -13,7 +14,7 @@ export const setHoneypotChannelId = (guildId: string, channelId: string): void =
   honeypotChannels.set(guildId, channelId);
 };
 
-export const loadHoneypotChannels = async (): Promise<void> => {
+export const loadHoneypotChannels = async (): Promise<number> => {
   const db = getDbClient();
   const settings = await db.serverChannelsSettings.findMany({
     where: { honeypotChannel: { not: null } },
@@ -25,6 +26,8 @@ export const loadHoneypotChannels = async (): Promise<void> => {
       honeypotChannels.set(setting.guildId, setting.honeypotChannel);
     }
   }
+
+  return honeypotChannels.size;
 };
 
 const BAN_DELETE_WINDOW_SECONDS = 3600;
@@ -48,6 +51,12 @@ export const handleHoneypotTrigger = async (message: Message<true>): Promise<voi
       reason: 'autoban - spambot',
     })
   );
+
+  setSpanAttributes({
+    'bot.honeypot.user_id': author.id,
+    'bot.honeypot.ban_success': result.isOk(),
+    'bot.honeypot.timestamp': Date.now(),
+  });
 
   if (result.isOk()) {
     logger.info(`[honeypot]: Banned ${author.username} from guild ${guild.name}`);

--- a/src/utils/message-processor.ts
+++ b/src/utils/message-processor.ts
@@ -9,10 +9,6 @@ const keywordMatched = (sentence: string, keyword: string): boolean => {
   return regex.test(sentence);
 };
 
-type CommandPromise = Promise<void> | void;
-
-type CommandPromises = Array<CommandPromise>;
-
 interface KeywordMatchCommand {
   matchers: Array<string>;
   fn: (message: Message<true>) => Promise<void>;
@@ -20,15 +16,20 @@ interface KeywordMatchCommand {
 
 type KeywordMatchCommands = Array<KeywordMatchCommand>;
 
-const processKeywordMatch = (message: Message<true>, config: KeywordMatchCommands): CommandPromises => {
-  return config.map((conf) => {
-    const hasKeyword = conf.matchers.some((keyword) => keywordMatched(message.content, keyword));
+interface KeywordMatchResult {
+  keyword: string;
+  promise: Promise<void>;
+}
 
-    if (!hasKeyword) {
+const processKeywordMatch = (message: Message<true>, config: KeywordMatchCommands): Array<KeywordMatchResult | undefined> => {
+  return config.map((conf) => {
+    const matchedKeyword = conf.matchers.find((keyword) => keywordMatched(message.content, keyword));
+
+    if (!matchedKeyword) {
       return undefined;
     }
 
-    return conf.fn(message);
+    return { keyword: matchedKeyword, promise: conf.fn(message) };
   });
 };
 
@@ -56,12 +57,15 @@ export const processMessage = async (message: Message<true>, config: CommandConf
         return;
       }
 
-      const keywordPromises = processKeywordMatch(message, config.keywordMatchCommands);
-      const hasKeywordMatch = keywordPromises.some((p) => p !== undefined);
-      span.setAttribute('bot.message.processed', hasKeywordMatch);
+      const keywordResults = processKeywordMatch(message, config.keywordMatchCommands);
+      const matches = keywordResults.filter((r): r is KeywordMatchResult => r !== undefined);
+      span.setAttribute('bot.message.processed', matches.length > 0);
+      if (matches.length > 0) {
+        span.setAttribute('bot.message.matched_keywords', matches.map((m) => m.keyword).join(','));
+      }
 
       try {
-        await Promise.all(keywordPromises);
+        await Promise.all(matches.map((m) => m.promise));
       } catch (error) {
         recordSpanError(error, 'err-keyword-processing-failed');
         logger.error('ERROR PROCESSING MESSAGE', error);

--- a/src/utils/tracer.test.ts
+++ b/src/utils/tracer.test.ts
@@ -56,8 +56,10 @@ describe('setSpanAttributes', () => {
       'bot.test.boolean': true,
     });
 
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith('bot.test.string', 'hello');
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith('bot.test.number', 42);
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith('bot.test.boolean', true);
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+      'bot.test.string': 'hello',
+      'bot.test.number': 42,
+      'bot.test.boolean': true,
+    });
   });
 });

--- a/src/utils/tracer.test.ts
+++ b/src/utils/tracer.test.ts
@@ -3,7 +3,7 @@ import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { ATTR_ERROR_TYPE } from '@opentelemetry/semantic-conventions';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
-import { recordSpanError } from './tracer';
+import { recordSpanError, setSpanAttributes } from './tracer';
 
 describe('recordSpanError', () => {
   afterEach(() => vi.restoreAllMocks());
@@ -35,5 +35,29 @@ describe('recordSpanError', () => {
     recordSpanError('string error', 'err-string');
 
     expect(mockSpan.recordException).toHaveBeenCalledWith(new Error('string error'));
+  });
+});
+
+describe('setSpanAttributes', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('is a no-op when there is no active span', () => {
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined);
+    expect(() => setSpanAttributes({ 'bot.test': 'value' })).not.toThrow();
+  });
+
+  it('sets all provided attributes on the active span', () => {
+    const mockSpan = mockDeep<Span>();
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan);
+
+    setSpanAttributes({
+      'bot.test.string': 'hello',
+      'bot.test.number': 42,
+      'bot.test.boolean': true,
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('bot.test.string', 'hello');
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('bot.test.number', 42);
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith('bot.test.boolean', true);
   });
 });

--- a/src/utils/tracer.ts
+++ b/src/utils/tracer.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode, trace } from '@opentelemetry/api';
+import { type Attributes, SpanStatusCode, trace } from '@opentelemetry/api';
 import { ATTR_ERROR_TYPE } from '@opentelemetry/semantic-conventions';
 
 export const tracer = trace.getTracer('discord-bot');
@@ -11,10 +11,9 @@ export function recordSpanError(error: unknown, slug: string): void {
   span.setAttribute(ATTR_ERROR_TYPE, slug);
 }
 
-export function setSpanAttributes(attributes: Record<string, string | number | boolean>): void {
+export function setSpanAttributes(attributes: Attributes): void {
   const span = trace.getActiveSpan();
   if (!span) return;
-  for (const [key, value] of Object.entries(attributes)) {
-    span.setAttribute(key, value);
-  }
+
+  span.setAttributes(attributes);
 }

--- a/src/utils/tracer.ts
+++ b/src/utils/tracer.ts
@@ -10,3 +10,11 @@ export function recordSpanError(error: unknown, slug: string): void {
   span.recordException(error instanceof Error ? error : new Error(String(error)));
   span.setAttribute(ATTR_ERROR_TYPE, slug);
 }
+
+export function setSpanAttributes(attributes: Record<string, string | number | boolean>): void {
+  const span = trace.getActiveSpan();
+  if (!span) return;
+  for (const [key, value] of Object.entries(attributes)) {
+    span.setAttribute(key, value);
+  }
+}


### PR DESCRIPTION
## Description

- Add `setSpanAttributes` helper to tracer utilities for enriching wide event spans with domain-specific attributes
- Enrich all DB/API command handlers (reputation, reminder, referral, weather, quote, aoc-leaderboard, server-settings, autobump, moderate) with span attributes
- Enrich message handlers (keyword match tracking, honeypot trigger, thankUserInMessage) with span attributes
- Record span errors via `recordSpanError` in all internal error paths that previously only logged and replied
- Refactor `processKeywordMatch` to track which keyword matched per handler

## Motivation and Context

Wide event spans from #301 only contained generic attributes (guild/channel/user IDs, command name). Command handlers have rich domain context (reputation values, weather locations, reminder timestamps, ban outcomes) that was lost. Errors caught internally via `Result.safe` never propagated to the top-level `recordSpanError`, making them invisible to OTel.

## How Has This Been Tested?

- `pnpm typecheck` passes
- `pnpm lint:fix:unsafe` passes with no fixes needed
- `pnpm test -- --run` — all 153 tests pass across 40 test files
- Manual verification with `ENABLE_OTEL=true` + Jaeger pending

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.