### PR TITLE
refactor: replace all try/catch/finally with Result.safe

### DIFF
--- a/.agents/rules/engineering-principles.md
+++ b/.agents/rules/engineering-principles.md
@@ -11,7 +11,7 @@
 
 > See also: [`docs/reference/08-error-handling.md`](../../docs/reference/08-error-handling.md)
 
-- **Use Result types**: Prefer `Ok`/`Err` from oxide.ts over throwing exceptions
+- **Use Result types**: Prefer `Ok`/`Err` from oxide.ts over throwing exceptions. Use `Result.safe` instead of try/catch/finally.
 - **Record span errors**: Use `recordSpanError` to attach errors to OTel spans
 - **Log errors**: Always log errors with winston logger
 - **User feedback**: Provide clear error messages to Discord users

--- a/bin/autobump.ts
+++ b/bin/autobump.ts
@@ -1,3 +1,4 @@
+import type { Span } from '@opentelemetry/api';
 import type { ThreadChannel } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDiscordClient } from '../src/clients';
@@ -8,86 +9,91 @@ import { recordSpanError, tracer } from '../src/utils/tracer';
 
 const DEFAULT_AUTOBUMP_MESSAGE = '👋 Thread auto-bumped to keep it active!';
 
-const bumpThread = async (thread: ThreadChannel, clientId?: string) => {
-  try {
-    const messages = await thread.messages.fetch({ limit: 100 });
+const performBump = async (thread: ThreadChannel, clientId?: string) => {
+  const messages = await thread.messages.fetch({ limit: 100 });
 
-    await thread.setArchived(false);
+  await thread.setArchived(false);
 
-    if (clientId) {
-      const botMessages = messages.filter((m) => m.author.bot && m.author.id === clientId);
+  if (clientId) {
+    const botMessages = messages.filter((m) => m.author.bot && m.author.id === clientId);
 
-      if (botMessages.size === 0) {
-        logger.warn(`[autobump]: No existing bot message found in thread ${thread.id}`);
-      } else {
-        await Promise.all(botMessages.map((m) => m.delete()));
-      }
+    if (botMessages.size === 0) {
+      logger.warn(`[autobump]: No existing bot message found in thread ${thread.id}`);
+    } else {
+      await Promise.all(botMessages.map((m) => m.delete()));
     }
-
-    await thread.send(DEFAULT_AUTOBUMP_MESSAGE);
-  } catch (error) {
-    logger.error(`[autobump]: Failed to bump thread ${thread.id}`, error);
   }
+
+  await thread.send(DEFAULT_AUTOBUMP_MESSAGE);
+};
+
+const bumpThread = async (thread: ThreadChannel, clientId?: string) => {
+  const op = await Result.safe(performBump(thread, clientId));
+  if (op.isErr()) {
+    logger.error(`[autobump]: Failed to bump thread ${thread.id}`, op.unwrapErr());
+  }
+};
+
+const handleAutobump = async (span: Span, token: string) => {
+  const settings = await Result.safe(listAllThreads());
+  if (settings.isErr()) {
+    recordSpanError(settings.unwrapErr(), 'err-autobump-list-failed');
+    logger.error('[autobump]: Cannot retrieve autobump thread lists', settings.unwrapErr());
+    return 1;
+  }
+
+  const data = settings.unwrap();
+  if (data.length === 0) {
+    logger.info('[autobump]: No autobump threads settings found');
+    return 0;
+  }
+
+  span.setAttribute(
+    'bot.autobump.thread_count',
+    data.reduce((sum, d) => sum + d.autobumpThreads.length, 0)
+  );
+
+  const client = await getDiscordClient({ token });
+  const clientId = client.user?.id;
+
+  const jobs = await data.reduce(
+    async (accumulator, { guildId, autobumpThreads }) => {
+      const guild = client.guilds.cache.find((g) => g.available && g.id === guildId);
+      if (!guild) {
+        logger.info(`[autobump]: Cannot find guild ${guildId} for autobump`);
+        return accumulator;
+      }
+
+      const prev = await accumulator;
+      logger.info(`[autobump]: Bumping ${autobumpThreads.length} threads in guild ${guild.name} (${guild.id})`);
+      const bumpPromises = autobumpThreads.map(async (id) => {
+        const thread = (await guild.channels.fetch(id)) as ThreadChannel;
+        await bumpThread(thread, clientId);
+        return { threadId: id, success: true };
+      });
+      const results = await Promise.all(bumpPromises);
+      logger.info(`[autobump]: Bumped ${results.filter((r) => r.success).length} threads in guild ${guild.name} (${guild.id})`);
+      return [...prev, ...results];
+    },
+    Promise.resolve([] as unknown[])
+  );
+
+  logger.info(`[autobump]: Thread autobump complete. Jobs: ${jobs.length}`);
+  return 0;
 };
 
 const autobump = async () => {
   const env = loadEnv();
   logger.info('AUTOBUMPING THREADS');
 
-  return tracer.startActiveSpan('autobump', async (span) => {
-    try {
-      const settings = await Result.safe(listAllThreads());
-      if (settings.isErr()) {
-        recordSpanError(settings.unwrapErr(), 'err-autobump-list-failed');
-        logger.error('[autobump]: Cannot retrieve autobump thread lists', settings.unwrapErr());
-        span.end();
-        process.exit(1);
-      }
-
-      const data = settings.unwrap();
-      if (data.length === 0) {
-        logger.info('[autobump]: No autobump threads settings found');
-        span.end();
-        process.exit(0);
-      }
-
-      span.setAttribute(
-        'bot.autobump.thread_count',
-        data.reduce((sum, d) => sum + d.autobumpThreads.length, 0)
-      );
-
-      const client = await getDiscordClient({ token: env.TOKEN });
-      const clientId = client.user?.id;
-
-      const jobs = await data.reduce(
-        async (accumulator, { guildId, autobumpThreads }) => {
-          const guild = client.guilds.cache.find((g) => g.available && g.id === guildId);
-          if (!guild) {
-            logger.info(`[autobump]: Cannot find guild ${guildId} for autobump`);
-            return accumulator;
-          }
-
-          const prev = await accumulator;
-          logger.info(`[autobump]: Bumping ${autobumpThreads.length} threads in guild ${guild.name} (${guild.id})`);
-          const bumpPromises = autobumpThreads.map(async (id) => {
-            const thread = (await guild.channels.fetch(id)) as ThreadChannel;
-            await bumpThread(thread, clientId);
-            return { threadId: id, success: true };
-          });
-          const results = await Promise.all(bumpPromises);
-          logger.info(`[autobump]: Bumped ${results.filter((r) => r.success).length} threads in guild ${guild.name} (${guild.id})`);
-          return [...prev, ...results];
-        },
-        Promise.resolve([] as unknown[])
-      );
-
-      logger.info(`[autobump]: Thread autobump complete. Jobs: ${jobs.length}`);
-      span.end();
-      process.exit(0);
-    } finally {
-      span.end();
-    }
+  const result = await tracer.startActiveSpan('autobump', async (span) => {
+    const op = await Result.safe(handleAutobump(span, env.TOKEN));
+    span.end();
+    return op;
   });
+
+  const exitCode = result.isOk() ? result.unwrap() : 1;
+  process.exit(exitCode);
 };
 
 autobump();

--- a/bin/broadcast-reminder.ts
+++ b/bin/broadcast-reminder.ts
@@ -1,3 +1,4 @@
+import type { Span } from '@opentelemetry/api';
 import { ChannelType } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDiscordClient } from '../src/clients';
@@ -8,84 +9,86 @@ import { loadEnv } from '../src/utils/load-env';
 import { logger } from '../src/utils/logger';
 import { recordSpanError, tracer } from '../src/utils/tracer';
 
+const handleBroadcast = async (span: Span, token: string) => {
+  const queryTime = getCurrentUnixTime();
+  span.setAttribute('bot.reminder.query_time', queryTime);
+
+  const reminders = await Result.safe(getReminderByTime(getCurrentUnixTime()));
+  if (reminders.isErr()) {
+    recordSpanError(reminders.unwrapErr(), 'err-broadcast-reminder-query-failed');
+    logger.error(`[broadcast-reminder]: Cannot retrieve reminders. Query Time: ${queryTime}`, reminders.unwrapErr());
+    return 1;
+  }
+
+  const remindersData = reminders.unwrap();
+  span.setAttribute('bot.reminder.count', remindersData.length);
+
+  if (remindersData.length === 0) {
+    logger.info(`[broadcast-reminder]: No reminders to broadcast. Query Time: ${queryTime}`);
+    return 0;
+  }
+
+  const client = await getDiscordClient({ token });
+
+  const jobs = await remindersData.reduce(
+    async (accumulator, reminder) => {
+      const guild = client.guilds.cache.find((g) => g.available && g.id === reminder.guildId);
+      if (!guild) {
+        logger.info(`[broadcast-reminder]: Cannot find guild ${reminder.guildId} for reminder`);
+        return accumulator;
+      }
+
+      const channelId = await Result.safe(getReminderChannel(guild.id));
+      if (channelId.isErr()) {
+        logger.info(`[broadcast-reminder]: Cannot find reminder channel settings for guild ${reminder.guildId}`);
+        return accumulator;
+      }
+
+      const data = channelId.unwrap();
+      if (!data) {
+        logger.info(`[broadcast-reminder]: Cannot unwrap reminder channel for guild ${reminder.guildId}`);
+        return accumulator;
+      }
+      const channel = client.channels.cache.get(data);
+      if (!channel) {
+        logger.info(`[broadcast-reminder]: Cannot find reminder channel id ${data} for guild ${reminder.guildId}`);
+        return accumulator;
+      }
+      if (channel.type !== ChannelType.GuildText) {
+        logger.info(`[broadcast-reminder]: Reminder channel id ${data} for guild ${reminder.guildId} is not a text channel`);
+        return accumulator;
+      }
+
+      const prev = await accumulator;
+
+      logger.info(`[broadcast-reminder]: Broadcasting reminder ${reminder.id} in guild ${guild.name} (${guild.id})`);
+      const message = formatReminderMessage(reminder);
+      const promise = channel.send(message);
+      logger.info(`[broadcast-reminder]: Broadcasted reminder ${reminder.id} in guild ${guild.name} (${guild.id})`);
+
+      return [...prev, promise];
+    },
+    Promise.resolve([] as unknown[])
+  );
+
+  await removeReminders(remindersData);
+
+  logger.info(`[broadcast-reminder]: Reminders fan out complete. Jobs: ${jobs.length}`);
+  return 0;
+};
+
 const broadcastReminder = async () => {
   const env = loadEnv();
   logger.info('BROADCASTING REMINDERS');
 
-  return tracer.startActiveSpan('broadcastReminder', async (span) => {
-    try {
-      const queryTime = getCurrentUnixTime();
-      span.setAttribute('bot.reminder.query_time', queryTime);
-
-      const reminders = await Result.safe(getReminderByTime(getCurrentUnixTime()));
-      if (reminders.isErr()) {
-        recordSpanError(reminders.unwrapErr(), 'err-broadcast-reminder-query-failed');
-        logger.error(`[broadcast-reminder]: Cannot retrieve reminders. Query Time: ${queryTime}`, reminders.unwrapErr());
-        span.end();
-        process.exit(1);
-      }
-
-      const remindersData = reminders.unwrap();
-      span.setAttribute('bot.reminder.count', remindersData.length);
-
-      if (remindersData.length === 0) {
-        logger.info(`[broadcast-reminder]: No reminders to broadcast. Query Time: ${queryTime}`);
-        span.end();
-        process.exit(0);
-      }
-
-      const client = await getDiscordClient({ token: env.TOKEN });
-
-      const jobs = await remindersData.reduce(
-        async (accumulator, reminder) => {
-          const guild = client.guilds.cache.find((g) => g.available && g.id === reminder.guildId);
-          if (!guild) {
-            logger.info(`[broadcast-reminder]: Cannot find guild ${reminder.guildId} for reminder`);
-            return accumulator;
-          }
-
-          const channelId = await Result.safe(getReminderChannel(guild.id));
-          if (channelId.isErr()) {
-            logger.info(`[broadcast-reminder]: Cannot find reminder channel settings for guild ${reminder.guildId}`);
-            return accumulator;
-          }
-
-          const data = channelId.unwrap();
-          if (!data) {
-            logger.info(`[broadcast-reminder]: Cannot unwrap reminder channel for guild ${reminder.guildId}`);
-            return accumulator;
-          }
-          const channel = client.channels.cache.get(data);
-          if (!channel) {
-            logger.info(`[broadcast-reminder]: Cannot find reminder channel id ${data} for guild ${reminder.guildId}`);
-            return accumulator;
-          }
-          if (channel.type !== ChannelType.GuildText) {
-            logger.info(`[broadcast-reminder]: Reminder channel id ${data} for guild ${reminder.guildId} is not a text channel`);
-            return accumulator;
-          }
-
-          const prev = await accumulator;
-
-          logger.info(`[broadcast-reminder]: Broadcasting reminder ${reminder.id} in guild ${guild.name} (${guild.id})`);
-          const message = formatReminderMessage(reminder);
-          const promise = channel.send(message);
-          logger.info(`[broadcast-reminder]: Broadcasted reminder ${reminder.id} in guild ${guild.name} (${guild.id})`);
-
-          return [...prev, promise];
-        },
-        Promise.resolve([] as unknown[])
-      );
-
-      await removeReminders(remindersData);
-
-      logger.info(`[broadcast-reminder]: Reminders fan out complete. Jobs: ${jobs.length}`);
-      span.end();
-      process.exit(0);
-    } finally {
-      span.end();
-    }
+  const result = await tracer.startActiveSpan('broadcastReminder', async (span) => {
+    const op = await Result.safe(handleBroadcast(span, env.TOKEN));
+    span.end();
+    return op;
   });
+
+  const exitCode = result.isOk() ? result.unwrap() : 1;
+  process.exit(exitCode);
 };
 
 broadcastReminder();

--- a/bin/cleanup-expired-referrals.ts
+++ b/bin/cleanup-expired-referrals.ts
@@ -4,27 +4,30 @@ import { loadEnv } from '../src/utils/load-env';
 import { logger } from '../src/utils/logger';
 import { recordSpanError, tracer } from '../src/utils/tracer';
 
+const handleCleanup = async () => {
+  const op = await Result.safe(cleanupExpiredCode());
+  if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-cleanup-referrals-failed');
+    logger.error('[cleanup-expired-referrals]: Error cleaning up expired referrals', op.unwrapErr());
+    return 1;
+  }
+
+  logger.info('[cleanup-expired-referrals]: Removed expired referrals');
+  return 0;
+};
+
 const cleanup = async () => {
   loadEnv();
   logger.info('[cleanup-expired-referrals]: CLEANING UP EXPIRED REFERRALS');
 
-  return tracer.startActiveSpan('cleanupExpiredReferrals', async (span) => {
-    try {
-      const op = await Result.safe(cleanupExpiredCode());
-      if (op.isErr()) {
-        recordSpanError(op.unwrapErr(), 'err-cleanup-referrals-failed');
-        logger.error('[cleanup-expired-referrals]: Error cleaning up expired referrals', op.unwrapErr());
-        span.end();
-        process.exit(1);
-      }
-
-      logger.info('[cleanup-expired-referrals]: Removed expired referrals');
-      span.end();
-      process.exit(0);
-    } finally {
-      span.end();
-    }
+  const result = await tracer.startActiveSpan('cleanupExpiredReferrals', async (span) => {
+    const op = await Result.safe(handleCleanup());
+    span.end();
+    return op;
   });
+
+  const exitCode = result.isOk() ? result.unwrap() : 1;
+  process.exit(exitCode);
 };
 
 cleanup();

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,4 +1,3 @@
-import type { Span } from '@opentelemetry/api';
 import { Events, type Message } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDiscordClient } from '../src/clients';
@@ -13,7 +12,7 @@ import { logger } from '../src/utils/logger';
 import { processMessage } from '../src/utils/message-processor';
 import { recordSpanError, setSpanAttributes, tracer } from '../src/utils/tracer';
 
-const handleDeployCommands = async (span: Span, { token, clientId }: Omit<DiscordRequestConfig, 'guildId'>) => {
+const handleDeployCommands = async ({ token, clientId }: Omit<DiscordRequestConfig, 'guildId'>) => {
   logger.info('[deploy-commands]: Deploying global commands in production mode');
   const commands = [...slashCommandList, ...contextMenuCommandList];
   const op = await Result.safe(deployGlobalCommands(commands, { token, clientId }));
@@ -34,7 +33,7 @@ const deployCommands = async ({ token, clientId, nodeEnv }: Omit<DiscordRequestC
   }
 
   const result = await tracer.startActiveSpan('deployCommands', async (span) => {
-    const op = await Result.safe(handleDeployCommands(span, { token, clientId }));
+    const op = await Result.safe(handleDeployCommands({ token, clientId }));
     span.end();
     return op;
   });

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,3 +1,4 @@
+import type { Span } from '@opentelemetry/api';
 import { Events, type Message } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getDiscordClient } from '../src/clients';
@@ -12,39 +13,49 @@ import { logger } from '../src/utils/logger';
 import { processMessage } from '../src/utils/message-processor';
 import { recordSpanError, setSpanAttributes, tracer } from '../src/utils/tracer';
 
+const handleDeployCommands = async (span: Span, { token, clientId }: Omit<DiscordRequestConfig, 'guildId'>) => {
+  logger.info('[deploy-commands]: Deploying global commands in production mode');
+  const commands = [...slashCommandList, ...contextMenuCommandList];
+  const op = await Result.safe(deployGlobalCommands(commands, { token, clientId }));
+  if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-deploy-commands-failed');
+    logger.error('[deploy-commands]: Cannot deploy global commands', op.unwrapErr());
+    return 1;
+  }
+
+  logger.info('[deploy-commands]: Successfully deployed global commands');
+  return 0;
+};
+
 const deployCommands = async ({ token, clientId, nodeEnv }: Omit<DiscordRequestConfig, 'guildId'> & { nodeEnv: ConfigSchema['NODE_ENV'] }) => {
   if (nodeEnv !== 'production') {
     logger.info('[deploy-commands]: Skipping command deployment in development mode');
     return;
   }
 
-  return tracer.startActiveSpan('deployCommands', async (span) => {
-    try {
-      logger.info('[deploy-commands]: Deploying global commands in production mode');
-      const commands = [...slashCommandList, ...contextMenuCommandList];
-      const op = await Result.safe(deployGlobalCommands(commands, { token, clientId }));
-      if (op.isErr()) {
-        recordSpanError(op.unwrapErr(), 'err-deploy-commands-failed');
-        logger.error('[deploy-commands]: Cannot deploy global commands', op.unwrapErr());
-        process.exit(1);
-      }
-
-      logger.info('[deploy-commands]: Successfully deployed global commands');
-    } finally {
-      span.end();
-    }
+  const result = await tracer.startActiveSpan('deployCommands', async (span) => {
+    const op = await Result.safe(handleDeployCommands(span, { token, clientId }));
+    span.end();
+    return op;
   });
+
+  if (result.isOk() && result.unwrap() === 1) process.exit(1);
+  if (result.isErr()) process.exit(1);
+};
+
+const handleLoadHoneypots = async () => {
+  const op = await Result.safe(loadHoneypotChannels());
+  if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-load-honeypots-failed');
+    logger.error('[honeypot]: Failed to load honeypot channels', op.unwrapErr());
+    return;
+  }
+  setSpanAttributes({ 'bot.honeypot.channel_count': op.unwrap() });
 };
 
 const loadHoneypots = async () => {
   return tracer.startActiveSpan('loadHoneypots', async (span) => {
-    const op = await Result.safe(loadHoneypotChannels());
-    if (op.isErr()) {
-      recordSpanError(op.unwrapErr(), 'err-load-honeypots-failed');
-      logger.error('[honeypot]: Failed to load honeypot channels', op.unwrapErr());
-      return;
-    }
-    setSpanAttributes({ 'bot.honeypot.channel_count': op.unwrap() });
+    await Result.safe(handleLoadHoneypots());
     span.end();
   });
 };

--- a/docs/reference/09-telemetry.md
+++ b/docs/reference/09-telemetry.md
@@ -12,21 +12,36 @@ Reference for the bot's [OpenTelemetry](https://opentelemetry.io/) (OTel) instru
 
 ## Span Lifecycle
 
-- Every span opened with `tracer.startActiveSpan()` **must** be ended gracefully via `span.end()`. If the code is wrapped in a `try/catch` block, there must be a `span.end()` in the `finally` to handle that.
-- Calling `process.exit()` in a script before `span.end()` will drop the span — it will never be exported.
+- Every span opened with `tracer.startActiveSpan()` **must** be ended gracefully via `span.end()`.
+- Wrap the span callback body in `Result.safe` so `span.end()` always runs without `try/finally`. Extract the logic into a named function at module level.
+- Calling `process.exit()` in a script before `span.end()` will drop the span — it will never be exported. In bin scripts, return an exit code from the span callback and call `process.exit()` after the span ends.
 - In production, background tasks use `BatchSpanProcessor`, which buffers spans and flushes on shutdown. The SIGTERM handler in `bin/telemetry.ts` handles graceful flush.
 
 ```typescript
-return tracer.startActiveSpan('operationName', async (span) => {
-  try {
-    // ... task logic
-  } catch (error) {
-    recordSpanError(error, 'err-operation-failed');
-    throw error;
-  } finally {
-    span.end();
+// Long-running process (bot, server)
+const handleOperation = async (span: Span) => {
+  span.setAttribute('bot.key', 'value');
+  const op = await Result.safe(doWork());
+  if (op.isErr()) {
+    recordSpanError(op.unwrapErr(), 'err-operation-failed');
+    return;
   }
+  // ... use op.unwrap()
+};
+
+return tracer.startActiveSpan('operationName', async (span) => {
+  await Result.safe(handleOperation(span));
+  span.end();
 });
+
+// Bin script (exits after completion)
+const result = await tracer.startActiveSpan('taskName', async (span) => {
+  const op = await Result.safe(handleTask(span));
+  span.end();
+  return op;
+});
+const exitCode = result.isOk() ? result.unwrap() : 1;
+process.exit(exitCode);
 ```
 
 ## Attribute Namespaces

--- a/src/utils/interaction-processor.ts
+++ b/src/utils/interaction-processor.ts
@@ -1,3 +1,4 @@
+import type { Span } from '@opentelemetry/api';
 import { type Interaction, InteractionType } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { commands as contextMenuCommandList } from '../context-menu-commands';
@@ -5,85 +6,86 @@ import { commands as slashCommandList } from '../slash-commands';
 import { logger } from './logger';
 import { recordSpanError, tracer } from './tracer';
 
+const handleInteraction = async (interaction: Interaction, span: Span) => {
+  if (interaction.guildId) span.setAttribute('discord.guild.id', interaction.guildId);
+  if (interaction.channelId) span.setAttribute('discord.channel.id', interaction.channelId);
+  span.setAttribute('enduser.id', interaction.user.id);
+
+  const isCommand = interaction.isChatInputCommand();
+  if (isCommand) {
+    const { commandName } = interaction;
+    span.setAttribute('bot.command.name', commandName);
+    span.setAttribute('discord.interaction.type', 'chatInputCommand');
+    logger.info(`[process-interaction]: RECEIVED COMMAND. COMMAND: ${commandName}`);
+    const command = slashCommandList.find((cmd) => cmd.data.name === commandName);
+    if (!command) {
+      logger.info(`[process-interaction]: COMMAND NOT FOUND: ${commandName}. Exiting...`);
+      return;
+    }
+
+    const op = await Result.safe(command.execute(interaction));
+    if (op.isErr()) {
+      recordSpanError(op.unwrapErr(), `err-command-${commandName}-failed`);
+      logger.error(`[process-interaction]: ERROR HANDLING COMMAND: ${commandName}`, op.unwrapErr());
+      return;
+    }
+
+    logger.info(`[process-interaction]: COMMAND HANDLED SUCCESSFULLY: ${commandName}`);
+    return;
+  }
+
+  const isContextMenuCommand = interaction.isContextMenuCommand();
+  if (isContextMenuCommand) {
+    const { commandName } = interaction;
+    span.setAttribute('bot.command.name', commandName);
+    span.setAttribute('discord.interaction.type', 'contextMenuCommand');
+    logger.info(`[process-interaction]: RECEIVED CONTEXT MENU COMMAND. COMMAND: ${commandName}`);
+    const command = contextMenuCommandList.find((cmd) => cmd.data.name === commandName);
+    if (!command) {
+      logger.info(`[process-interaction]: CONTEXT MENU COMMAND NOT FOUND: ${commandName}. Exiting...`);
+      return;
+    }
+
+    const op = await Result.safe(command.execute(interaction));
+    if (op.isErr()) {
+      recordSpanError(op.unwrapErr(), `err-contextmenu-${commandName}-failed`);
+      logger.error(`[process-interaction]: ERROR HANDLING CONTEXT MENU COMMAND: ${commandName}`, op.unwrapErr());
+      return;
+    }
+
+    logger.info(`[process-interaction]: CONTEXT MENU COMMAND HANDLED SUCCESSFULLY: ${commandName}`);
+    return;
+  }
+
+  const isAutocomplete = interaction.type === InteractionType.ApplicationCommandAutocomplete;
+  if (isAutocomplete) {
+    const { commandName } = interaction;
+    span.setAttribute('bot.command.name', commandName);
+    span.setAttribute('discord.interaction.type', 'autocomplete');
+    logger.info(`[process-interaction]: RECEIVED AUTOCOMPLETE. COMMAND: ${commandName}`);
+    const command = slashCommandList.find((cmd) => cmd.data.name === commandName);
+    if (!command || !command.autocomplete) {
+      logger.info(`[process-interaction]: COMMAND AUTOCOMPLETE NOT FOUND: ${commandName}. Exiting...`);
+      return;
+    }
+
+    const op = await Result.safe(command.autocomplete(interaction));
+    if (op.isErr()) {
+      recordSpanError(op.unwrapErr(), `err-autocomplete-${commandName}-failed`);
+      logger.error(`[process-interaction]: ERROR HANDLING AUTOCOMPLETE: ${commandName}`, op.unwrapErr());
+      return;
+    }
+
+    logger.info(`[process-interaction]: AUTOCOMPLETE HANDLED SUCCESSFULLY: ${commandName}`);
+    return;
+  }
+
+  logger.info(`[process-interaction]: INTERACTION TYPE NOT RECOGNIZED. TYPE: ${interaction.type}`);
+};
+
 export const processInteraction = async (interaction: Interaction): Promise<void> => {
   return tracer.startActiveSpan('processInteraction', async (span) => {
-    try {
-      if (interaction.guildId) span.setAttribute('discord.guild.id', interaction.guildId);
-      if (interaction.channelId) span.setAttribute('discord.channel.id', interaction.channelId);
-      span.setAttribute('enduser.id', interaction.user.id);
-
-      const isCommand = interaction.isChatInputCommand();
-      if (isCommand) {
-        const { commandName } = interaction;
-        span.setAttribute('bot.command.name', commandName);
-        span.setAttribute('discord.interaction.type', 'chatInputCommand');
-        logger.info(`[process-interaction]: RECEIVED COMMAND. COMMAND: ${commandName}`);
-        const command = slashCommandList.find((cmd) => cmd.data.name === commandName);
-        if (!command) {
-          logger.info(`[process-interaction]: COMMAND NOT FOUND: ${commandName}. Exiting...`);
-          return;
-        }
-
-        const op = await Result.safe(command.execute(interaction));
-        if (op.isErr()) {
-          recordSpanError(op.unwrapErr(), `err-command-${commandName}-failed`);
-          logger.error(`[process-interaction]: ERROR HANDLING COMMAND: ${commandName}`, op.unwrapErr());
-          return;
-        }
-
-        logger.info(`[process-interaction]: COMMAND HANDLED SUCCESSFULLY: ${commandName}`);
-        return;
-      }
-
-      const isContextMenuCommand = interaction.isContextMenuCommand();
-      if (isContextMenuCommand) {
-        const { commandName } = interaction;
-        span.setAttribute('bot.command.name', commandName);
-        span.setAttribute('discord.interaction.type', 'contextMenuCommand');
-        logger.info(`[process-interaction]: RECEIVED CONTEXT MENU COMMAND. COMMAND: ${commandName}`);
-        const command = contextMenuCommandList.find((cmd) => cmd.data.name === commandName);
-        if (!command) {
-          logger.info(`[process-interaction]: CONTEXT MENU COMMAND NOT FOUND: ${commandName}. Exiting...`);
-          return;
-        }
-
-        const op = await Result.safe(command.execute(interaction));
-        if (op.isErr()) {
-          recordSpanError(op.unwrapErr(), `err-contextmenu-${commandName}-failed`);
-          logger.error(`[process-interaction]: ERROR HANDLING CONTEXT MENU COMMAND: ${commandName}`, op.unwrapErr());
-          return;
-        }
-
-        logger.info(`[process-interaction]: CONTEXT MENU COMMAND HANDLED SUCCESSFULLY: ${commandName}`);
-        return;
-      }
-
-      const isAutocomplete = interaction.type === InteractionType.ApplicationCommandAutocomplete;
-      if (isAutocomplete) {
-        const { commandName } = interaction;
-        span.setAttribute('bot.command.name', commandName);
-        span.setAttribute('discord.interaction.type', 'autocomplete');
-        logger.info(`[process-interaction]: RECEIVED AUTOCOMPLETE. COMMAND: ${commandName}`);
-        const command = slashCommandList.find((cmd) => cmd.data.name === commandName);
-        if (!command || !command.autocomplete) {
-          logger.info(`[process-interaction]: COMMAND AUTOCOMPLETE NOT FOUND: ${commandName}. Exiting...`);
-          return;
-        }
-
-        const op = await Result.safe(command.autocomplete(interaction));
-        if (op.isErr()) {
-          recordSpanError(op.unwrapErr(), `err-autocomplete-${commandName}-failed`);
-          logger.error(`[process-interaction]: ERROR HANDLING AUTOCOMPLETE: ${commandName}`, op.unwrapErr());
-          return;
-        }
-
-        logger.info(`[process-interaction]: AUTOCOMPLETE HANDLED SUCCESSFULLY: ${commandName}`);
-        return;
-      }
-
-      logger.info(`[process-interaction]: INTERACTION TYPE NOT RECOGNIZED. TYPE: ${interaction.type}`);
-    } finally {
-      span.end();
-    }
+    await Result.safe(handleInteraction(interaction, span));
+    span.end();
   });
 };

--- a/src/utils/message-processor.ts
+++ b/src/utils/message-processor.ts
@@ -1,3 +1,4 @@
+import type { Span } from '@opentelemetry/api';
 import type { Message } from 'discord.js';
 import { Result } from 'oxide.ts';
 import { getHoneypotChannelId, handleHoneypotTrigger } from './honeypot-handler';
@@ -37,41 +38,41 @@ export interface CommandConfig {
   keywordMatchCommands: KeywordMatchCommands;
 }
 
+const handleMessage = async (message: Message<true>, config: CommandConfig, span: Span) => {
+  span.setAttribute('discord.channel.id', message.channelId);
+  span.setAttribute('discord.message.id', message.id);
+  span.setAttribute('discord.guild.id', message.guildId);
+  span.setAttribute('enduser.id', message.author.id);
+
+  const honeypotChannelId = getHoneypotChannelId(message.guildId);
+  if (honeypotChannelId && message.channelId === honeypotChannelId) {
+    span.setAttribute('bot.message.processed', true);
+    span.setAttribute('bot.message.honeypot', true);
+    const result = await Result.safe(handleHoneypotTrigger(message));
+    if (result.isErr()) {
+      recordSpanError(result.unwrapErr(), 'err-honeypot-trigger-failed');
+      logger.error('[honeypot]: Error processing honeypot trigger', result.unwrapErr());
+    }
+    return;
+  }
+
+  const keywordResults = processKeywordMatch(message, config.keywordMatchCommands);
+  const matches = keywordResults.filter((r): r is KeywordMatchResult => r !== undefined);
+  span.setAttribute('bot.message.processed', matches.length > 0);
+  if (matches.length > 0) {
+    span.setAttribute('bot.message.matched_keywords', matches.map((m) => m.keyword).join(','));
+  }
+
+  const keywordResult = await Result.safe(Promise.all(matches.map((m) => m.promise)));
+  if (keywordResult.isErr()) {
+    recordSpanError(keywordResult.unwrapErr(), 'err-keyword-processing-failed');
+    logger.error('ERROR PROCESSING MESSAGE', keywordResult.unwrapErr());
+  }
+};
+
 export const processMessage = async (message: Message<true>, config: CommandConfig): Promise<void> => {
   return tracer.startActiveSpan('processMessage', async (span) => {
-    try {
-      span.setAttribute('discord.channel.id', message.channelId);
-      span.setAttribute('discord.message.id', message.id);
-      span.setAttribute('discord.guild.id', message.guildId);
-      span.setAttribute('enduser.id', message.author.id);
-
-      const honeypotChannelId = getHoneypotChannelId(message.guildId);
-      if (honeypotChannelId && message.channelId === honeypotChannelId) {
-        span.setAttribute('bot.message.processed', true);
-        span.setAttribute('bot.message.honeypot', true);
-        const result = await Result.safe(handleHoneypotTrigger(message));
-        if (result.isErr()) {
-          recordSpanError(result.unwrapErr(), 'err-honeypot-trigger-failed');
-          logger.error('[honeypot]: Error processing honeypot trigger', result.unwrapErr());
-        }
-        return;
-      }
-
-      const keywordResults = processKeywordMatch(message, config.keywordMatchCommands);
-      const matches = keywordResults.filter((r): r is KeywordMatchResult => r !== undefined);
-      span.setAttribute('bot.message.processed', matches.length > 0);
-      if (matches.length > 0) {
-        span.setAttribute('bot.message.matched_keywords', matches.map((m) => m.keyword).join(','));
-      }
-
-      try {
-        await Promise.all(matches.map((m) => m.promise));
-      } catch (error) {
-        recordSpanError(error, 'err-keyword-processing-failed');
-        logger.error('ERROR PROCESSING MESSAGE', error);
-      }
-    } finally {
-      span.end();
-    }
+    await Result.safe(handleMessage(message, config, span));
+    span.end();
   });
 };


### PR DESCRIPTION
## Description

- Replace all 9 try/catch/finally blocks across `src/` and `bin/` with `Result.safe` from oxide.ts
- Extract span callback logic into named functions at module level for readability
- Fix span leak in `loadHoneypots` where `span.end()` was missing on the error path
- For bin scripts, move `process.exit()` outside the span callback so spans always end before the process terminates
- Eliminate duplicate `span.end()` calls in bin scripts (autobump had 3, cleanup and broadcast had 3 each)

## Motivation and Context

The codebase uses oxide.ts `Result` types everywhere except around OTel span lifecycle, where try/finally was used for `span.end()` cleanup. Since `Result.safe` never rejects, wrapping the span body in `Result.safe` guarantees `span.end()` always runs without needing try/finally. This aligns error handling with the rest of the codebase.

## How Has This Been Tested?

- `pnpm typecheck` passes
- `pnpm lint:fix:unsafe` passes
- `pnpm test -- --run` — all 154 tests pass across 40 test files
- `rg "try {" --type ts src/ bin/` — confirms zero remaining try blocks

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.