### PR TITLE
build: replace local jaeger with otel-desktop-viewer

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*": ["oxlint --fix", "oxfmt --write"]
+  "*": ["oxlint --fix --no-error-on-unmatched-pattern", "oxfmt --write --no-error-on-unmatched-pattern"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,14 @@ services:
     volumes:
       - ./.docker/volume/db/data:/var/lib/postgresql/data
 
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: vait_jaeger
+  tracing:
+    # Images are built specifically per architecture. Uncomment the one matching your machine.
+    # On AMD64/Intel-based machines
+    image: ghcr.io/ctrlspice/otel-desktop-viewer:latest-amd64
+    # On ARM-based machines (e.g. Apple Silicon, Raspberry Pi)
+    # image: ghcr.io/ctrlspice/otel-desktop-viewer:latest-arm64
+    container_name: discord_bot_tracing
     ports:
       - 4317:4317
       - 4318:4318
-      - 9411:9411
-      - 14250:14250
-      - 14268:14268
-      - 14269:14269
-      - 16686:16686
+      - 8000:8000

--- a/docs/explanation/01-architecture.md
+++ b/docs/explanation/01-architecture.md
@@ -55,7 +55,7 @@ This was chosen over vendor-specific SDKs (e.g., Axiom's own SDK) because:
 - **Vendor independence** — switching backends (Axiom, Grafana, Datadog) requires only a config change, not a complete code rewrite, as long as the provider accepts the [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otlp/) (or OTLP)
 - **Standardised semantic conventions** — attributes like `enduser.id` and `error.type` follow an industry standard, making traces readable by anyone familiar with OTel
 
-Locally, [Jaeger](https://www.jaegertracing.io/) provides a lightweight trace viewer with span graph visualisation. In production, traces export to [Axiom](https://axiom.co/) for centralised observability. The `FilteringSpanProcessor` reduces production costs by dropping unprocessed messages entirely and sampling success spans at 1%, while always exporting error spans.
+Locally, [otel-desktop-viewer](https://github.com/CtrlSpice/otel-desktop-viewer) provides a lightweight trace viewer with span graph visualisation. In production, traces export to [Axiom](https://axiom.co/) for centralised observability. The `FilteringSpanProcessor` reduces production costs by dropping unprocessed messages entirely and sampling success spans at 1%, while always exporting error spans.
 
 OTel is disabled by default (`ENABLE_OTEL=false`) and has no impact on bot behaviour when off.
 

--- a/docs/how-to/01-quick-start.md
+++ b/docs/how-to/01-quick-start.md
@@ -48,13 +48,13 @@ pnpm run start
 
 ### Optional: Local Observability
 
-The bot supports [OpenTelemetry](https://opentelemetry.io/) tracing for debugging and understanding request flows. Locally, [Jaeger](https://www.jaegertracing.io/) provides a trace viewer with span graph visualisation. See [Why OpenTelemetry](../explanation/01-architecture.md#why-opentelemetry) for the design rationale.
+The bot supports [OpenTelemetry](https://opentelemetry.io/) tracing for debugging and understanding request flows. Locally, [otel-desktop-viewer](https://github.com/CtrlSpice/otel-desktop-viewer) provides a trace viewer with span graph visualisation. See [Why OpenTelemetry](../explanation/01-architecture.md#why-opentelemetry) for the design rationale.
 
 ```bash
-docker compose up -d db jaeger
+docker compose up -d db tracing
 ```
 
-Set `ENABLE_OTEL=true` in your `.env`. View traces in the Jaeger UI at `http://localhost:16686`.
+Set `ENABLE_OTEL=true` in your `.env`. View traces in the otel-desktop-viewer UI at `http://localhost:8000`.
 
 ## Next Steps
 

--- a/docs/reference/05-environment-variables.md
+++ b/docs/reference/05-environment-variables.md
@@ -35,12 +35,12 @@ All configuration is via environment variables in the `.env` file. Copy `.env.di
 
 ## OpenTelemetry
 
-| Variable                      | Required          | Default            | Description                                                                                                                                               |
-| ----------------------------- | ----------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ENABLE_OTEL`                 | No                | `false`            | Enable OpenTelemetry trace collection (`true` or `false`)                                                                                                 |
-| `OTEL_DEBUG`                  | No                | `false`            | Enable OTel SDK diagnostic logging                                                                                                                        |
-| `OTEL_SERVICE_NAME`           | No                | `vait-discord-bot` | Service name for trace attribution                                                                                                                        |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | When OTel enabled | —                  | OTLP HTTP base endpoint URL. The SDK appends signal-specific paths (`/v1/traces`, `/v1/logs`) automatically. Local dev: `http://localhost:4318` (Jaeger). |
+| Variable                      | Required          | Default            | Description                                                                                                                                                            |
+| ----------------------------- | ----------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ENABLE_OTEL`                 | No                | `false`            | Enable OpenTelemetry trace collection (`true` or `false`)                                                                                                              |
+| `OTEL_DEBUG`                  | No                | `false`            | Enable OTel SDK diagnostic logging                                                                                                                                     |
+| `OTEL_SERVICE_NAME`           | No                | `vait-discord-bot` | Service name for trace attribution                                                                                                                                     |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | When OTel enabled | —                  | OTLP HTTP base endpoint URL. The SDK appends signal-specific paths (`/v1/traces`, `/v1/logs`) automatically. Local dev: `http://localhost:4318` (otel-desktop-viewer). |
 
 When `ENABLE_OTEL=true` in production, `AXIOM_TOKEN` and `AXIOM_DATASET` are also required (traces and logs are exported to Axiom via the OTel pipeline). When `ENABLE_OTEL=false`, logs fall back to the direct `@axiomhq/winston` transport.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Originally, we wanted to have somewhere locally in our machines to show
that our OTel traces are propagating correctly, so I went with Jaeger
because I thought that was a simple and light all-in-one setup
(comparing to other solutions like the LGTM stack). But now that I have
discovered another tool, which is more fit for purpose as we only need
to SEE the traces locally not trying to emulate a whole platform, the
otel-desktop-viewer does the job while being lighter than Jaeger itself.
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer related only changes (tools and/or documentation only, non-functional changes)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
